### PR TITLE
Code review for splitting up main file

### DIFF
--- a/bin/Macronify/CMakeLists.txt
+++ b/bin/Macronify/CMakeLists.txt
@@ -1,6 +1,11 @@
 set(LLVM_LINK_COMPONENTS Core Support AsmParser)
 
-add_executable(macronify Main.cpp)
+add_executable(macronify
+    MacroniCodeGenVisitorMixin.cpp
+    MacroniRewriters.cpp
+    Main.cpp
+    ParseAST.cpp
+)
 llvm_update_compile_flags(macronify)
 
 target_link_libraries(macronify

--- a/bin/Macronify/Globals.hpp
+++ b/bin/Macronify/Globals.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <mlir/IR/Builders.h>
+#include <optional>
+#include <pasta/AST/AST.h>
+
+// TODO(bpp): Instead of using a global variable for the PASTA AST and MLIR
+// context, find out how to pass these to a CodeGen object.
+extern std::optional<pasta::AST> ast;
+extern std::optional<mlir::Builder> builder;

--- a/bin/Macronify/MacroniCodeGenVisitorMixin.cpp
+++ b/bin/Macronify/MacroniCodeGenVisitorMixin.cpp
@@ -1,0 +1,58 @@
+#include "MacroniCodeGenVisitorMixin.hpp"
+
+namespace macroni {
+    std::optional<pasta::MacroSubstitution> lowest_unvisited_substitution(
+        pasta::Stmt &stmt,
+        std::set<pasta::MacroSubstitution> &visited
+    ) {
+        auto subs = stmt.AlignedSubstitutions();
+        for (auto sub : subs) {
+            // Don't visit macros more than once
+            if (visited.contains(sub)) {
+                continue;
+            }
+
+            // Only visit pre-expanded forms of function-like expansions.
+            if (auto exp = pasta::MacroExpansion::From(sub)) {
+                bool is_pre_expansion = (exp->Arguments().empty() ||
+                                         exp->IsArgumentPreExpansion());
+                if (!is_pre_expansion) {
+                    continue;
+                }
+            }
+
+            // Mark this substitution as visited so we don't visit it again.
+            visited.insert(sub);
+            return sub;
+        }
+        return std::nullopt;
+    }
+
+    bool is_function_like(pasta::MacroSubstitution &sub,
+                          bool default_ /* = false */) {
+        if (auto exp = pasta::MacroExpansion::From(sub)) {
+            if (auto def = exp->Definition()) {
+                return def->IsFunctionLike();
+            }
+        }
+        return default_;
+    }
+
+    std::vector<llvm::StringRef> get_parameter_names(
+        pasta::MacroSubstitution &sub) {
+        std::vector<llvm::StringRef> param_names;
+        if (auto exp = pasta::MacroExpansion::From(sub)) {
+            if (auto def = exp->Definition()) {
+                for (auto macro_tok : def->Parameters()) {
+                    if (auto bt = macro_tok.BeginToken()) {
+                        param_names.push_back(bt->Data());
+                    } else {
+                        param_names.push_back(
+                            "<a nameless macro parameter>");
+                    }
+                }
+            }
+        }
+        return param_names;
+    }
+} // namespace macroni

--- a/bin/Macronify/MacroniCodeGenVisitorMixin.hpp
+++ b/bin/Macronify/MacroniCodeGenVisitorMixin.hpp
@@ -1,0 +1,124 @@
+#pragma once
+
+#include "Globals.hpp"
+#include "MacroniMetaGenerator.hpp"
+#include <macroni/Dialect/Macroni/MacroniDialect.hpp>
+#include <macroni/Dialect/Macroni/MacroniOps.hpp>
+#include <vast/Translation/CodeGenVisitor.hpp>
+
+namespace macroni {
+    // Given a set of visited substitutions, returns the lowest substitutions in
+    // this macros chain of aligned substitution that has not yet been visited,
+    // and marks it as visited.
+    std::optional<pasta::MacroSubstitution> lowest_unvisited_substitution(
+        pasta::Stmt &stmt,
+        std::set<pasta::MacroSubstitution> &visited);
+
+    // Given a substitution, returns whether that substitution is an expansion
+    // of a function-like macro. Returns the given default value if the
+    // substitution lacks the necessary information to determine this.
+    bool is_function_like(pasta::MacroSubstitution &sub, bool default_ = false);
+
+    // Given a substitution, returns the names of the names of the
+    // substitution's macro parameters, if any.
+    std::vector<llvm::StringRef>
+        get_parameter_names(pasta::MacroSubstitution &sub);
+
+    template<typename Derived>
+    struct MacroniCodeGenVisitorMixin
+        : vast::cg::CodeGenDeclVisitorMixin<Derived>
+        , vast::cg::CodeGenStmtVisitorMixin<Derived>
+        , vast::cg::CodeGenTypeVisitorWithDataLayoutMixin<Derived> {
+        using DeclVisitor = vast::cg::CodeGenDeclVisitorMixin<Derived>;
+        using StmtVisitor = vast::cg::CodeGenStmtVisitorMixin<Derived>;
+        using TypeVisitor =
+            vast::cg::CodeGenTypeVisitorWithDataLayoutMixin<Derived>;
+
+        using DeclVisitor::Visit;
+        using TypeVisitor::Visit;
+        using StmtVisitor::make_maybe_value_yield_region;
+
+        std::set<pasta::MacroSubstitution> visited;
+        std::int64_t lock_level = 0;
+
+        mlir::Operation *Visit(const clang::Stmt *stmt) {
+            if (clang::isa<clang::ImplicitValueInitExpr,
+                clang::ImplicitCastExpr>(stmt)) {
+                // Don't visit implicit expressions
+                return VisitNonMacro(stmt);
+            }
+
+            // Find the lowest macro that covers this statement, if any
+            auto pasta_stmt = ast->Adopt(stmt);
+            auto sub = lowest_unvisited_substitution(pasta_stmt, visited);
+            if (!sub) {
+                // If no substitution covers this statement, visit it normally.
+                return VisitNonMacro(stmt);
+            }
+
+            // Get the substitution's location, name, parameter names, and
+            // whether it is function-like
+            auto loc = StmtVisitor::meta_location(*sub);
+            auto name_tok = sub->NameOrOperator();
+            auto macro_name = (name_tok
+                               ? name_tok->Data()
+                               : "<a nameless macro>");
+            auto function_like = is_function_like(*sub);
+            auto parameter_names = get_parameter_names(*sub);
+
+            // We call `make_maybe_value_yield_region` here because a macro may
+            // not expand to an expression
+            auto [region, return_type] = make_maybe_value_yield_region(stmt);
+
+            // Check if the macro is an expansion or a parameter, and return the
+            // appropriate operation
+            if (sub->Kind() == pasta::MacroKind::kExpansion) {
+                return StmtVisitor::template make<macroni::MacroExpansion>(
+                    loc,
+                    builder->getStringAttr(llvm::Twine(macro_name)),
+                    builder->getStrArrayAttr(llvm::ArrayRef(parameter_names)),
+                    builder->getBoolAttr(function_like),
+                    return_type,
+                    std::move(region)
+                );
+            } else {
+                return StmtVisitor::template make<macroni::MacroParameter>(
+                    loc,
+                    builder->getStringAttr(llvm::Twine(macro_name)),
+                    return_type,
+                    std::move(region)
+                );
+            }
+        }
+
+        mlir::Operation *VisitNonMacro(const clang::Stmt *stmt) {
+            auto op = StmtVisitor::Visit(stmt);
+            auto call_op = mlir::dyn_cast<vast::hl::CallOp>(op);
+            if (!call_op) {
+                return op;
+            }
+
+            auto name = call_op.getCalleeAttr().getValue();
+            if ("rcu_read_lock" == name) {
+                call_op.getOperation()->setAttr(
+                    "lock_level",
+                    builder->getI64IntegerAttr(lock_level));
+                lock_level++;
+            } else if ("rcu_read_unlock" == name) {
+                lock_level--;
+                call_op.getOperation()->setAttr(
+                    "lock_level",
+                    builder->getI64IntegerAttr(lock_level));
+            }
+            return op;
+        }
+    };
+
+    template<typename Derived>
+    using MacroniVisitorConfig = vast::cg::CodeGenFallBackVisitorMixin<Derived,
+        MacroniCodeGenVisitorMixin, vast::cg::DefaultFallBackVisitorMixin>;
+
+    using MacroniVisitor = vast::cg::CodeGenVisitor<MacroniVisitorConfig,
+        MacroniMetaGenerator>;
+
+} // namespace macroni

--- a/bin/Macronify/MacroniMetaGenerator.hpp
+++ b/bin/Macronify/MacroniMetaGenerator.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "vast/Translation/CodeGenMeta.hpp"
+
+namespace macroni {
+    struct MacroniMetaGenerator {
+        MacroniMetaGenerator(const pasta::AST &ast, mlir::MLIRContext *mctx)
+            : ast(ast), mctx(mctx) {}
+
+        vast::cg::DefaultMeta get(const clang::FullSourceLoc &loc) const {
+            if (!loc.isValid()) {
+                return { mlir::FileLineColLoc::get(mctx, "<invalid>", 0, 0) };
+            }
+            auto file_entry = loc.getFileEntry();
+            auto file = file_entry ? file_entry->getName() : "unknown";
+            auto line = loc.getLineNumber();
+            auto col = loc.getColumnNumber();
+            return { mlir::FileLineColLoc::get(mctx, file, line, col) };
+        }
+
+        vast::cg::DefaultMeta get(const clang::SourceLocation &loc) const {
+            clang::SourceManager &sm = ast.UnderlyingAST().getSourceManager();
+            return get(clang::FullSourceLoc(loc, sm));
+        }
+
+        vast::cg::DefaultMeta get(const clang::Decl *decl) const {
+            return get(decl->getLocation());
+        }
+
+        vast::cg::DefaultMeta get(const clang::Stmt *stmt) const {
+            // TODO: use SourceRange
+            return get(stmt->getBeginLoc());
+        }
+
+        vast::cg::DefaultMeta get(const clang::Expr *expr) const {
+            // TODO: use SourceRange
+            return get(expr->getExprLoc());
+        }
+
+        vast::cg::DefaultMeta get(const clang::TypeLoc &loc) const {
+            // TODO: use SourceRange
+            return get(loc.getBeginLoc());
+        }
+
+        vast::cg::DefaultMeta get(const clang::Type *type) const {
+            return get(clang::TypeLoc(type, nullptr));
+        }
+
+        vast::cg::DefaultMeta get(clang::QualType type) const {
+            return get(clang::TypeLoc(type, nullptr));
+        }
+
+        vast::cg::DefaultMeta get(pasta::MacroSubstitution &sub) const {
+            // TODO(bpp): Define this to something that makes sense. Right now
+            // this just returns an invalid source location.
+            return get(clang::SourceLocation());
+        }
+
+        const pasta::AST &ast;
+        mlir::MLIRContext *mctx;
+    };
+} // namespace macroni

--- a/bin/Macronify/MacroniRewriters.cpp
+++ b/bin/Macronify/MacroniRewriters.cpp
@@ -1,0 +1,281 @@
+#include "MacroniRewriters.hpp"
+
+namespace macroni {
+    bool has_results(mlir::Operation *op) {
+        return op->getNumResults() > 0;
+    }
+
+    bool is_get_user(macroni::MacroExpansion &exp) {
+        return has_results(exp) &&
+            exp.getParameterNames().size() == 2 &&
+            exp.getMacroName() == "get_user";
+    }
+
+    bool is_offsetof(macroni::MacroExpansion &exp) {
+        return has_results(exp) &&
+            exp.getParameterNames().size() == 2 &&
+            exp.getMacroName() == "offsetof";
+    }
+
+    bool is_container_of(macroni::MacroExpansion &exp) {
+        return has_results(exp) &&
+            exp.getParameterNames().size() == 3 &&
+            exp.getMacroName() == "container_of";
+    }
+
+    bool is_rcu_dereference(macroni::MacroExpansion &exp) {
+        return has_results(exp) &&
+            exp.getParameterNames().size() == 1 &&
+            exp.getMacroName() == "rcu_dereference";
+    }
+
+    bool is_smp_mb(macroni::MacroExpansion &exp) {
+        return has_results(exp) &&
+            exp.getParameterNames().size() == 0 &&
+            exp.getMacroName() == "smp_mb";
+    }
+
+    mlir::LogicalResult rewrite_get_user(
+        macroni::MacroExpansion exp,
+        mlir::PatternRewriter &rewriter) {
+        if (!is_get_user(exp)) {
+            return mlir::failure();
+        }
+        mlir::Operation *x = nullptr;
+        mlir::Operation *ptr = nullptr;
+        exp.getExpansion().walk([&](mlir::Operation *op) {
+            if (auto mp = mlir::dyn_cast<macroni::MacroParameter>(op)) {
+                auto name = mp.getParameterName();
+                if (!x && name == "x") {
+                    x = op;
+                } else if (!ptr && name == "ptr") {
+                    ptr = op;
+                }
+            }});
+        auto is_legal = (x &&
+                         ptr &&
+                         x->getNumResults() == 1 &&
+                         ptr->getNumResults() == 1);
+        if (!is_legal) {
+            return mlir::failure();
+        }
+
+        // The x and ptr macro parameters are expanded inside of the
+        // expansion of get_user(), so if we simply replaced the original
+        // macro expansion with the GetUser kernel operation, we would lose
+        // the arguments. Therefore we clone the arguments to lift them out
+        // of the macro expansion, and pass them to the GetUser operation.
+        // NOTE(bpp): Maybe we should create an operation for lifted macro
+        // parameters to make it possible to distinguish normal macro
+        // parameters from ones that have been lifted?
+        auto x_clone = rewriter.clone(*x);
+        auto ptr_clone = rewriter.clone(*ptr);
+        auto result_type = exp.getType(0);
+        auto x_res = x_clone->getResult(0);
+        auto ptr_res = ptr_clone->getResult(0);
+        using GE = ::macroni::kernel::GetUser;
+        rewriter.replaceOpWithNewOp<GE>(exp, result_type, x_res, ptr_res);
+        return mlir::success();
+    }
+
+    mlir::LogicalResult rewrite_offsetof(
+        macroni::MacroExpansion exp,
+        mlir::PatternRewriter &rewriter) {
+        if (!is_offsetof(exp)) {
+            return mlir::failure();
+        }
+        std::optional<mlir::TypeAttr> type;
+        std::optional<mlir::StringAttr> member;
+        exp.getExpansion().walk([&](mlir::Operation *op) {
+            if (auto member_op = mlir::dyn_cast<vast::hl::RecordMemberOp>(op)) {
+                auto record = member_op.getRecord();
+                auto record_ty = record.getType();
+                using PT = vast::hl::PointerType;
+                if (auto pty = mlir::dyn_cast<PT>(record_ty)) {
+                    auto element_ty = pty.getElementType();
+                    auto ty_attr = mlir::TypeAttr::get(element_ty);
+                    type = ty_attr;
+                } else {
+                    auto ty_attr = mlir::TypeAttr::get(record_ty);
+                    type = ty_attr;
+                }
+                member = member_op.getNameAttr();
+            }});
+        auto is_legal = type && member;
+        if (!is_legal) {
+            return mlir::failure();
+        }
+
+        auto op = exp.getOperation();
+        auto result_type = exp.getType(0);
+        using OO = ::macroni::kernel::OffsetOf;
+        rewriter.replaceOpWithNewOp<OO>(op, result_type, *type, *member);
+        return mlir::success();
+    }
+
+    mlir::LogicalResult rewrite_container_of(
+        macroni::MacroExpansion exp,
+        mlir::PatternRewriter &rewriter) {
+        if (!is_container_of(exp)) {
+            return mlir::failure();
+        }
+        mlir::Operation *ptr = nullptr;
+        std::optional<mlir::TypeAttr> type;
+        std::optional<mlir::StringAttr> member;
+        using RMO = vast::hl::RecordMemberOp;
+        exp.getExpansion().walk([&](mlir::Operation *op) {
+            if (auto mp = mlir::dyn_cast<macroni::MacroParameter>(op)) {
+                auto param_name = mp.getParameterName();
+                if ("ptr" == param_name) {
+                    ptr = op;
+                }
+            } else if (auto member_op = mlir::dyn_cast<RMO>(op)) {
+                auto record = member_op.getRecord();
+                auto record_ty = record.getType();
+                using PT = vast::hl::PointerType;
+                if (auto pty = mlir::dyn_cast<PT>(record_ty)) {
+                    auto elem_ty = pty.getElementType();
+                    auto ty_attr = mlir::TypeAttr::get(elem_ty);
+                    type = ty_attr;
+                } else {
+                    auto ty_attr = mlir::TypeAttr::get(record_ty);
+                    type = ty_attr;
+                }
+                member = member_op.getNameAttr();
+            }});
+        auto is_legal = ptr && type && member;
+        if (!is_legal) {
+            return mlir::failure();
+        }
+
+        auto op = exp.getOperation();
+        auto ptr_clone = rewriter.clone(*ptr);
+        auto exp_ty = exp.getType(0);
+        auto ptr_res = ptr_clone->getResult(0);
+
+        using CO = ::macroni::kernel::ContainerOf;
+        rewriter.replaceOpWithNewOp<CO>(op, exp_ty, ptr_res, *type, *member);
+        return mlir::success();
+    }
+
+    mlir::LogicalResult rewrite_rcu_dereference(
+        macroni::MacroExpansion exp,
+        mlir::PatternRewriter &rewriter) {
+        if (!is_rcu_dereference(exp)) {
+            return mlir::failure();
+        }
+        mlir::Operation *p = nullptr;
+        exp.getExpansion().walk([&](mlir::Operation *op) {
+            if (auto param = mlir::dyn_cast<macroni::MacroParameter>(op)) {
+                auto param_name = param.getParameterName();
+                if (param_name == "p") {
+                    p = op;
+                }
+            }});
+        auto is_legal = p != nullptr;
+        if (!is_legal) {
+            return mlir::failure();
+        }
+
+        auto op = exp.getOperation();
+        auto p_clone = rewriter.clone(*p);
+        auto res_ty = exp.getType(0);
+        auto p_res = p_clone->getResult(0);
+        using RCUD = ::macroni::kernel::RCUDereference;
+        rewriter.replaceOpWithNewOp<RCUD>(op, res_ty, p_res);
+        return mlir::success();
+    }
+
+    mlir::LogicalResult rewrite_smp_mb(
+        macroni::MacroExpansion exp,
+        mlir::PatternRewriter &rewriter) {
+        if (!is_smp_mb(exp)) {
+            return mlir::failure();
+        }
+
+        auto op = exp.getOperation();
+        auto res_ty = exp.getType(0);
+        rewriter.replaceOpWithNewOp<kernel::SMPMB>(op, res_ty);
+        return mlir::success();
+    }
+
+    mlir::LogicalResult rewrite_list_for_each(
+        vast::hl::ForOp for_op,
+        mlir::PatternRewriter &rewriter) {
+        mlir::Operation *pos = nullptr;
+        mlir::Operation *head = nullptr;
+        for_op.getCondRegion().walk(
+            [&](mlir::Operation *op) {
+                using MP = macroni::MacroParameter;
+                if (auto param_op = mlir::dyn_cast<MP>(op)) {
+                    if (param_op.getParameterName() == "pos") {
+                        pos = op;
+                    } else if (param_op.getParameterName() == "head") {
+                        head = op;
+                    }
+                }
+            }
+        );
+        auto is_legal = pos && head;
+        if (!is_legal) {
+            return mlir::failure();
+        }
+
+        auto op = for_op.getOperation();
+        auto pos_clone = rewriter.clone(*pos);
+        auto head_clone = rewriter.clone(*head);
+        auto pos_res = pos_clone->getResult(0);
+        auto head_res = head_clone->getResult(0);
+        auto reg = std::make_unique<mlir::Region>();
+        reg->takeBody(for_op.getBodyRegion());
+        using LFE = ::macroni::kernel::ListForEach;
+        rewriter.replaceOpWithNewOp<LFE>(op, pos_res, head_res, std::move(reg));
+        return mlir::success();
+    }
+
+    llvm::APInt get_lock_level(mlir::Operation *op) {
+        using IA = mlir::IntegerAttr;
+        return op->getAttrOfType<IA>("lock_level").getValue();
+    }
+
+    mlir::LogicalResult rewrite_rcu_read_unlock(
+        vast::hl::CallOp call_op,
+        mlir::PatternRewriter &rewriter) {
+        auto name = call_op.getCalleeAttr().getValue();
+        if ("rcu_read_unlock" != name) {
+            return mlir::failure();
+        }
+        auto unlock_op = call_op.getOperation();
+        auto unlock_level = get_lock_level(unlock_op);
+        mlir::Operation *lock_op = nullptr;
+        for (auto op = unlock_op; op; op = op->getPrevNode()) {
+            if (auto call_op = mlir::dyn_cast<vast::hl::CallOp>(op)) {
+                name = call_op.getCalleeAttr().getValue();
+                if ("rcu_read_lock" == name) {
+                    auto lock_level = get_lock_level(op);
+                    if (unlock_level == lock_level) {
+                        lock_op = op;
+                        break;
+                    }
+                }
+            }
+        }
+        auto is_legal = lock_op != nullptr;
+        if (!is_legal) {
+            return mlir::failure();
+        }
+
+        rewriter.setInsertionPointAfter(lock_op);
+        using CS = kernel::RCUCriticalSection;
+        auto cs = rewriter.replaceOpWithNewOp<CS>(lock_op);
+        auto cs_block = rewriter.createBlock(&cs.getBodyRegion());
+        for (auto op = cs->getNextNode(); op != unlock_op;) {
+            auto temp = op->getNextNode();
+            op->moveBefore(cs_block, cs_block->end());
+            op = temp;
+        }
+        rewriter.eraseOp(unlock_op);
+        return mlir::success();
+    }
+
+} // namespace macroni

--- a/bin/Macronify/MacroniRewriters.hpp
+++ b/bin/Macronify/MacroniRewriters.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <macroni/Dialect/Kernel/KernelDialect.hpp>
+#include <macroni/Dialect/Kernel/KernelOps.hpp>
+#include <macroni/Dialect/Macroni/MacroniDialect.hpp>
+#include <macroni/Dialect/Macroni/MacroniOps.hpp>
+#include <mlir/Transforms/DialectConversion.h>
+#include <vast/Dialect/HighLevel/HighLevelOps.hpp>
+
+namespace macroni {
+    bool has_results(mlir::Operation *op);
+    bool is_get_user(macroni::MacroExpansion &exp);
+    bool is_offsetof(macroni::MacroExpansion &exp);
+    bool is_container_of(macroni::MacroExpansion &exp);
+    bool is_rcu_dereference(macroni::MacroExpansion &exp);
+    bool is_smp_mb(macroni::MacroExpansion &exp);
+
+    using ME = macroni::MacroExpansion;
+    using PR = mlir::PatternRewriter;
+    mlir::LogicalResult rewrite_get_user(ME exp, PR &rewriter);
+    mlir::LogicalResult rewrite_offsetof(ME exp, PR &rewriter);
+    mlir::LogicalResult rewrite_container_of(ME exp, PR &rewriter);
+    mlir::LogicalResult rewrite_rcu_dereference(ME exp, PR &rewriter);
+    mlir::LogicalResult rewrite_smp_mb(ME exp, PR &rewriter);
+
+    using FO = vast::hl::ForOp;
+    mlir::LogicalResult rewrite_list_for_each(FO for_op, PR &rewriter);
+
+    llvm::APInt get_lock_level(mlir::Operation *op);
+    using CO = vast::hl::CallOp;
+    mlir::LogicalResult rewrite_rcu_read_unlock(CO call_op, PR &rewriter);
+
+} // namespace macroni

--- a/bin/Macronify/Main.cpp
+++ b/bin/Macronify/Main.cpp
@@ -4,731 +4,79 @@
 // This source code is licensed in accordance with the terms specified in
 // the LICENSE file found in the root directory of this source tree.
 
-
-#include <clang/AST/ASTContext.h>
-#include <clang/Tooling/Tooling.h>
-#include <llvm/Support/raw_ostream.h>
-#include <mlir/InitAllDialects.h>
-#include <mlir/InitAllPasses.h>
-#include <mlir/IR/Builders.h>
-#include <mlir/IR/Dialect.h>
-#include <mlir/IR/MLIRContext.h>
-#include <mlir/IR/OperationSupport.h>
+#include "Globals.hpp"
+#include "MacroniCodeGenVisitorMixin.hpp"
+#include "MacroniMetaGenerator.hpp"
+#include "MacroniRewriters.hpp"
+#include "ParseAST.hpp"
+#include <iostream>
+#include <llvm/Support/CommandLine.h>
 #include <mlir/Pass/Pass.h>
 #include <mlir/Pass/PassManager.h>
-#include <mlir/Support/TypeID.h>
-#include <mlir/Tools/mlir-translate/MlirTranslateMain.h>
-#include <mlir/Tools/mlir-translate/Translation.h>
-
-#include <clang/AST/ASTConsumer.h>
-#include <clang/AST/RecursiveASTVisitor.h>
-#include <clang/Frontend/CompilerInstance.h>
-#include <clang/Frontend/FrontendAction.h>
-#include <clang/Tooling/CommonOptionsParser.h>
-
-#include <pasta/AST/AST.h>
-#include <pasta/AST/Decl.h>
-#include <pasta/Compile/Command.h>
-#include <pasta/Compile/Compiler.h>
-#include <pasta/Compile/Job.h>
-#include <pasta/Util/ArgumentVector.h>
-#include <pasta/Util/FileSystem.h>
-#include <pasta/Util/Init.h>
-
-#include <vast/Util/Common.hpp>
-#include <vast/Translation/CodeGenContext.hpp>
-#include <vast/Translation/CodeGenVisitor.hpp>
-#include <vast/Dialect/Dialects.hpp>
-#include <vast/Conversion/Passes.hpp>
-#include <vast/Translation/CodeGen.hpp>
-#include <vast/Translation/Register.hpp>
-#include <vast/Translation/CodeGenDriver.hpp>
-#include <vast/Translation/CodeGenTypeDriver.hpp>
-
-#include <macroni/Dialect/Macroni/MacroniDialect.hpp>
-#include <macroni/Dialect/Macroni/MacroniOps.hpp>
-#include <macroni/Dialect/Kernel/KernelDialect.hpp>
-#include <macroni/Dialect/Kernel/KernelOps.hpp>
-
-#include <cstdlib>
-#include <iostream>
-#include <memory>
-#include <string>
+#include <mlir/Transforms/GreedyPatternRewriteDriver.h>
+#include <mlir/Transforms/Passes.h>
 #include <optional>
-#include <algorithm>
-#include <set>
-#include <map>
-
-using Op = mlir::Operation;
-
-static const constexpr char get_user[] = "get_user";
-static const constexpr char offsetof[] = "offsetof";
-static const constexpr char container_of[] = "container_of";
-static const constexpr char rcu_read_lock[] = "rcu_read_lock";
-static const constexpr char rcu_read_unlock[] = "rcu_read_unlock";
-static const constexpr char rcu_dereference[] = "rcu_dereference";
-static const constexpr char smp_mb[] = "smp_mb";
-
-// TODO(bpp): Instead of using a global variable for the PASTA AST and MLIR
-// context, find out how to pass these to a CodeGen object.
-std::optional<pasta::AST> ast = std::nullopt;
-std::optional<mlir::MLIRContext> mctx = std::nullopt;
-std::optional<mlir::Builder> builder = std::nullopt;
-
-// TODO(bpp): Find a way to pass information along from the dynamic legality
-// callbacks to the conversion methods without using global variables
-std::map<Op *, Op *> get_user_to_x;
-std::map<Op *, Op *> get_user_to_ptr;
-
-std::map<Op *, mlir::TypeAttr> offsetof_to_type;
-std::map<Op *, mlir::StringAttr> offsetof_to_member;
-
-std::map<Op *, Op *> container_of_to_ptr;
-std::map<Op *, mlir::TypeAttr> container_of_to_type;
-std::map<Op *, mlir::StringAttr> container_of_to_member;
-
-std::map<Op *, Op *> list_for_each_to_pos;
-std::map<Op *, Op *> list_for_each_to_head;
-
-std::map<Op *, Op *> unlock_to_lock;
-
-std::map<Op *, Op *> rcu_dereference_to_p;
-
-static inline llvm::APInt get_lock_level(Op *op) {
-    return op->getAttrOfType<mlir::IntegerAttr>("lock_level").getValue();
-}
-
-namespace macroni {
-
-    // NOTE(bpp): It may be a good idea to also transform substitutions of
-    // get_user()'s parameters into special operations as well, to get even
-    // more information about the macro. This would let us match against all the
-    // various definitions of get_user, and all its substitutions of all its
-    // parameters.
-
-    struct macro_expansion_to_get_user
-        : mlir::OpConversionPattern< macroni::MacroExpansion > {
-        using parent_t = mlir::OpConversionPattern<macroni::MacroExpansion>;
-        using parent_t::parent_t;
-
-        mlir::LogicalResult matchAndRewrite(
-            macroni::MacroExpansion exp,
-            macroni::MacroExpansion::Adaptor adaptor,
-            mlir::ConversionPatternRewriter &rewriter) const override {
-
-            if (exp.getMacroName() != get_user) {
-                return mlir::failure();
-            }
-
-            Op *op = exp.getOperation(),
-                *x = get_user_to_x.at(op),
-                *ptr = get_user_to_ptr.at(op),
-                *x_clone = rewriter.clone(*x),
-                *ptr_clone = rewriter.clone(*ptr);
-            mlir::Type result_type = exp.getType(0);
-            mlir::Value x_val = x_clone->getResult(0),
-                ptr_val = ptr_clone->getResult(0);
-
-            using GE = ::macroni::kernel::GetUser;
-            rewriter.replaceOpWithNewOp<GE>(op, result_type, x_val, ptr_val);
-
-            return mlir::success();
-        }
-    };
-
-    struct macro_expansion_to_offsetof
-        : mlir::OpConversionPattern< macroni::MacroExpansion > {
-        using parent_t = mlir::OpConversionPattern<macroni::MacroExpansion>;
-        using parent_t::parent_t;
-
-        mlir::LogicalResult matchAndRewrite(
-            macroni::MacroExpansion exp,
-            macroni::MacroExpansion::Adaptor adaptor,
-            mlir::ConversionPatternRewriter &rewriter) const override {
-
-            if (exp.getMacroName() != offsetof) {
-                return mlir::failure();
-            }
-
-            Op *op = exp.getOperation();
-            mlir::TypeAttr type = offsetof_to_type.at(op);
-            mlir::StringAttr member = offsetof_to_member.at(op);
-            mlir::Type result_type = exp.getType(0);
-
-            using OO = ::macroni::kernel::OffsetOf;
-            rewriter.replaceOpWithNewOp<OO>(op, result_type, type, member);
-
-            return mlir::success();
-        }
-    };
-
-    struct macro_expansion_to_container_of
-        : mlir::OpConversionPattern< macroni::MacroExpansion > {
-        using parent_t = mlir::OpConversionPattern<macroni::MacroExpansion>;
-        using parent_t::parent_t;
-
-        mlir::LogicalResult matchAndRewrite(
-            macroni::MacroExpansion exp,
-            macroni::MacroExpansion::Adaptor adaptor,
-            mlir::ConversionPatternRewriter &rewriter) const override {
-            if (exp.getMacroName() != container_of) {
-                return mlir::failure();
-            }
-
-            Op *op = exp.getOperation(),
-                *ptr = container_of_to_ptr.at(op),
-                *ptr_clone = rewriter.clone(*ptr);
-            mlir::TypeAttr type = container_of_to_type.at(op);
-            mlir::StringAttr member = container_of_to_member.at(op);
-            mlir::Type res_ty = exp.getType(0);
-            mlir::Value ptr_val = ptr_clone->getResult(0);
-
-            using CO = ::macroni::kernel::ContainerOf;
-            rewriter.replaceOpWithNewOp<CO>(op, res_ty, ptr_val, type, member);
-
-            return mlir::success();
-        }
-    };
-
-    struct macro_expansion_to_rcu_dereference
-        : mlir::OpConversionPattern< macroni::MacroExpansion > {
-        using parent_t = mlir::OpConversionPattern<macroni::MacroExpansion>;
-        using parent_t::parent_t;
-
-        mlir::LogicalResult matchAndRewrite(
-            macroni::MacroExpansion exp,
-            macroni::MacroExpansion::Adaptor adaptor,
-            mlir::ConversionPatternRewriter &rewriter) const override {
-            if (exp.getMacroName() != rcu_dereference) {
-                return mlir::failure();
-            }
-
-            Op *op = exp.getOperation(),
-                *p = rcu_dereference_to_p.at(op),
-                *p_clone = rewriter.clone(*p);
-            mlir::Type res_ty = exp.getType(0);
-            mlir::Value p_val = p_clone->getResult(0);
-
-            using RCUD = ::macroni::kernel::RCUDereference;
-            rewriter.replaceOpWithNewOp<RCUD>(op, res_ty, p_val);
-
-            return mlir::success();
-        }
-    };
-
-    struct macro_expansion_to_smp_mb
-        : mlir::OpConversionPattern< macroni::MacroExpansion > {
-        using parent_t = mlir::OpConversionPattern<macroni::MacroExpansion>;
-        using parent_t::parent_t;
-
-        mlir::LogicalResult matchAndRewrite(
-            macroni::MacroExpansion exp,
-            macroni::MacroExpansion::Adaptor adaptor,
-            mlir::ConversionPatternRewriter &rewriter) const override {
-            if (exp.getMacroName() != smp_mb) {
-                return mlir::failure();
-            }
-
-            Op *op = exp.getOperation();
-            mlir::Type res_ty = exp.getType(0);
-
-            using SMPMB = ::macroni::kernel::SMPMB;
-            rewriter.replaceOpWithNewOp<SMPMB>(op, res_ty);
-
-            return mlir::success();
-        }
-    };
-
-    struct for_to_list_for_each
-        : mlir::OpConversionPattern< vast::hl::ForOp > {
-        using parent_t = mlir::OpConversionPattern<vast::hl::ForOp>;
-        using parent_t::parent_t;
-
-        mlir::LogicalResult matchAndRewrite(
-            vast::hl::ForOp for_op,
-            vast::hl::ForOp::Adaptor adaptor,
-            mlir::ConversionPatternRewriter &rewriter) const override {
-            Op *op = for_op.getOperation(),
-                *pos = list_for_each_to_pos.at(op),
-                *head = list_for_each_to_head.at(op),
-                *pos_clone = rewriter.clone(*pos),
-                *head_clone = rewriter.clone(*head);
-
-            mlir::Value pos_val = pos_clone->getResult(0),
-                head_val = head_clone->getResult(0);
-
-            auto reg = std::make_unique<mlir::Region>();
-
-            reg->takeBody(for_op.getBodyRegion());
-
-            using LFE = ::macroni::kernel::ListForEach;
-            rewriter.replaceOpWithNewOp<LFE>(for_op, pos_val, head_val,
-                                             std::move(reg));
-
-            return mlir::success();
-        }
-    };
-
-    struct rcu_read_unlock_to_rcu_critical_section
-        : mlir::OpConversionPattern< vast::hl::CallOp > {
-        using parent_t = mlir::OpConversionPattern<vast::hl::CallOp>;
-        using parent_t::parent_t;
-
-        mlir::LogicalResult matchAndRewrite(
-            vast::hl::CallOp rcu_read_unlock_call,
-            vast::hl::CallOp::Adaptor adaptor,
-            mlir::ConversionPatternRewriter &rewriter) const override {
-
-            Op *unlock_op = rcu_read_unlock_call.getOperation(),
-                *lock_op = unlock_to_lock.at(unlock_op);
-
-            using CS = kernel::RCUCriticalSection;
-            rewriter.setInsertionPointAfter(lock_op);
-            CS cs = rewriter.replaceOpWithNewOp<CS>(lock_op);
-            mlir::Block *cs_block = rewriter.createBlock(&cs.getBodyRegion());
-
-            Op *op = cs->getNextNode();
-            while (op != unlock_op) {
-                Op *temp = op->getNextNode();
-                op->moveBefore(cs_block, cs_block->end());
-                op = temp;
-            }
-            rewriter.eraseOp(unlock_op);
-
-            return mlir::success();
-        }
-    };
-
-    struct MacroniMetaGenerator {
-        MacroniMetaGenerator(const pasta::AST &ast, mlir::MLIRContext *mctx)
-            : ast(ast), mctx(mctx) {}
-
-        vast::cg::DefaultMeta get(const clang::FullSourceLoc &loc) const {
-            if (!loc.isValid()) {
-                return { mlir::FileLineColLoc::get(mctx, "<invalid>", 0, 0) };
-            }
-            auto file_entry = loc.getFileEntry();
-            auto file = file_entry ? file_entry->getName() : "unknown";
-            auto line = loc.getLineNumber();
-            auto col = loc.getColumnNumber();
-            return { mlir::FileLineColLoc::get(mctx, file, line, col) };
-        }
-
-        vast::cg::DefaultMeta get(const clang::SourceLocation &loc) const {
-            clang::SourceManager &sm = ast.UnderlyingAST().getSourceManager();
-            return get(clang::FullSourceLoc(loc, sm));
-        }
-
-        vast::cg::DefaultMeta get(const clang::Decl *decl) const {
-            return get(decl->getLocation());
-        }
-
-        vast::cg::DefaultMeta get(const clang::Stmt *stmt) const {
-            // TODO: use SourceRange
-            return get(stmt->getBeginLoc());
-        }
-
-        vast::cg::DefaultMeta get(const clang::Expr *expr) const {
-            // TODO: use SourceRange
-            return get(expr->getExprLoc());
-        }
-
-        vast::cg::DefaultMeta get(const clang::TypeLoc &loc) const {
-            // TODO: use SourceRange
-            return get(loc.getBeginLoc());
-        }
-
-        vast::cg::DefaultMeta get(const clang::Type *type) const {
-            return get(clang::TypeLoc(type, nullptr));
-        }
-
-        vast::cg::DefaultMeta get(clang::QualType type) const {
-            return get(clang::TypeLoc(type, nullptr));
-        }
-
-        vast::cg::DefaultMeta get(pasta::MacroSubstitution &sub) const {
-            // TODO(bpp): Define this to something that makes sense. Right now
-            // this just returns an invalid source location.
-            return get(clang::SourceLocation());
-        }
-
-        const pasta::AST &ast;
-        mlir::MLIRContext *mctx;
-    };
-
-    template< typename Derived >
-    struct CodeGenVisitorMixin
-        : vast::cg::CodeGenDeclVisitorMixin< Derived >
-        , vast::cg::CodeGenStmtVisitorMixin< Derived >
-        , vast::cg::CodeGenTypeVisitorWithDataLayoutMixin< Derived >
-    {
-        using DeclVisitor = vast::cg::CodeGenDeclVisitorMixin< Derived >;
-        using StmtVisitor = vast::cg::CodeGenStmtVisitorMixin< Derived >;
-        using TypeVisitor =
-            vast::cg::CodeGenTypeVisitorWithDataLayoutMixin< Derived >;
-
-        using DeclVisitor::Visit;
-        using TypeVisitor::Visit;
-
-        std::set<pasta::MacroSubstitution> visited;
-
-        int64_t lock_level = 0;
-
-        Op *Visit(const clang::Stmt *stmt) {
-            if (clang::isa<clang::ImplicitValueInitExpr,
-                clang::ImplicitCastExpr>(stmt)) {
-                // Don't visit implicit expressions
-                return VisitNonMacro(stmt);
-            }
-
-            // Find the lowest macro that covers this statement, if any
-            const auto pasta_stmt = ast->Adopt(stmt);
-            std::optional<pasta::MacroSubstitution> lowest_sub = std::nullopt;
-            auto subs = pasta_stmt.AlignedSubstitutions();
-            for (auto sub : subs) {
-                // Don't visit macros more than once
-                if (visited.contains(sub)) {
-                    continue;
-                }
-
-                // Only visit pre-expanded forms of function-like expansions.
-                if (auto exp = pasta::MacroExpansion::From(sub)) {
-                    bool is_pre_expansion = (exp->Arguments().empty() ||
-                                             exp->IsArgumentPreExpansion());
-                    if (!is_pre_expansion) {
-                        continue;
-                    }
-                }
-
-                // Mark this substitution as visited so we don't visit it again.
-                visited.insert(sub);
-                lowest_sub = sub;
-                break;
-            }
-
-            if (!lowest_sub) {
-                // If no substitution covers this statement, visit it normally.
-                return VisitNonMacro(stmt);
-            }
-
-            // Get the substitution's location, name, parameter names, and
-            // whether it is function-like
-            mlir::Location loc = StmtVisitor::meta_location(*lowest_sub);
-            std::string_view macro_name = "<a nameless macro>";
-            bool function_like = false;
-            std::vector<llvm::StringRef> param_names;
-            if (auto sub = pasta::MacroSubstitution::From(*lowest_sub)) {
-                if (auto name = sub->NameOrOperator()) {
-                    macro_name = name->Data();
-                }
-                if (auto exp = pasta::MacroExpansion::From(*sub)) {
-                    if (auto def = exp->Definition()) {
-                        function_like = def->IsFunctionLike();
-                        for (auto macro_tok : def->Parameters()) {
-                            if (auto bt = macro_tok.BeginToken()) {
-                                param_names.push_back(bt->Data());
-                            }
-                        }
-                    }
-                }
-            }
-
-            // We call `make_maybe_value_yield_region` here because a macro may
-            // not expand to an expression
-            auto [region, return_type] =
-                StmtVisitor::make_maybe_value_yield_region(stmt);
-
-            // Check if the macro is an expansion or a parameter, and return the
-            // appropriate operation
-            if (lowest_sub->Kind() == pasta::MacroKind::kExpansion) {
-                return StmtVisitor::template make<macroni::MacroExpansion>(
-                    loc,
-                    builder->getStringAttr(llvm::Twine(macro_name)),
-                    builder->getStrArrayAttr(llvm::ArrayRef(param_names)),
-                    builder->getBoolAttr(function_like),
-                    return_type,
-                    std::move(region)
-                );
-            } else {
-                return StmtVisitor::template make<macroni::MacroParameter>(
-                    loc,
-                    builder->getStringAttr(llvm::Twine(macro_name)),
-                    return_type,
-                    std::move(region)
-                );
-            }
-        }
-
-        Op *VisitNonMacro(const clang::Stmt *stmt) {
-            auto op = StmtVisitor::Visit(stmt);
-            if (vast::hl::CallOp call_op =
-                mlir::dyn_cast<vast::hl::CallOp>(op)) {
-                auto name = call_op.getCalleeAttr().getValue();
-                if ("rcu_read_lock" == name) {
-                    call_op.getOperation()->setAttr(
-                        "lock_level",
-                        builder->getI64IntegerAttr(lock_level));
-                    lock_level++;
-                } else if ("rcu_read_unlock" == name) {
-                    lock_level--;
-                    call_op.getOperation()->setAttr(
-                        "lock_level",
-                        builder->getI64IntegerAttr(lock_level));
-                }
-            }
-            return op;
-        }
-    };
-
-    template< typename Derived >
-    using VisitorConfig = vast::cg::CodeGenFallBackVisitorMixin< Derived,
-        CodeGenVisitorMixin,
-        vast::cg::DefaultFallBackVisitorMixin
-    >;
-
-    using Visitor =
-        vast::cg::CodeGenVisitor<VisitorConfig, MacroniMetaGenerator>;
-
-} // namespace macroni
-
-static llvm::cl::list< std::string > compiler_args(
-    "ccopts", llvm::cl::ZeroOrMore, llvm::cl::desc("Specify compiler options")
-);
+#include <pasta/AST/AST.h>
+#include <vast/Translation/CodeGen.hpp>
+
+std::optional<pasta::AST> ast;
+std::optional<mlir::Builder> builder;
 
 int main(int argc, char **argv) {
-
-    pasta::InitPasta initializer;
-    pasta::FileManager fm(pasta::FileSystem::CreateNative());
-    auto maybe_compiler =
-        pasta::Compiler::CreateHostCompiler(fm, pasta::TargetLanguage::kCXX);
-    if (!maybe_compiler.Succeeded()) {
-        std::cerr << maybe_compiler.TakeError() << std::endl;
-        return EXIT_FAILURE;
-    }
-
-    auto maybe_cwd = (pasta::FileSystem::From(maybe_compiler.Value())
-                      ->CurrentWorkingDirectory());
-    if (!maybe_cwd.Succeeded()) {
-        std::cerr << maybe_compiler.TakeError() << std::endl;
-        return EXIT_FAILURE;
-    }
-
-    const pasta::ArgumentVector args(argc - 1, &argv[1]);
-    auto maybe_command = pasta::CompileCommand::CreateFromArguments(
-        args, maybe_cwd.TakeValue());
-    if (!maybe_command.Succeeded()) {
-        std::cerr << maybe_command.TakeError() << std::endl;
-        return EXIT_FAILURE;
-    }
-
-    const auto command = maybe_command.TakeValue();
-    auto maybe_jobs = maybe_compiler->CreateJobsForCommand(command);
-    if (!maybe_jobs.Succeeded()) {
-        std::cerr << maybe_jobs.TakeError() << std::endl;
-        return EXIT_FAILURE;
-    }
-
-    for (const auto &job : maybe_jobs.TakeValue()) {
-        auto maybe_ast = job.Run();
-        if (!maybe_ast.Succeeded()) {
-            std::cerr << maybe_ast.TakeError() << std::endl;
-            return EXIT_FAILURE;
+    bool convert = false;
+    for (int i = 0; i < argc; i++) {
+        if (strncmp("--convert", argv[i], 10) == 0) {
+            convert = true;
         }
-
-        ast.emplace(maybe_ast.TakeValue());
-
-        mlir::DialectRegistry registry;
-
-        // Register the MLIR dialects we will be converting to
-        registry.insert<
-            vast::hl::HighLevelDialect,
-            macroni::macroni::MacroniDialect,
-            macroni::kernel::KernelDialect
-        >();
-        mctx.emplace(registry);
-        macroni::MacroniMetaGenerator meta(*ast, &*mctx);
-        vast::cg::CodeGenBase<macroni::Visitor> codegen(&*mctx, meta);
-        builder.emplace(&*mctx);
-
-        codegen.append_to_module(ast->UnderlyingAST().getTranslationUnitDecl());
-        mlir::OwningOpRef<mlir::ModuleOp> mod = codegen.freeze();
-
-        // TODO(bpp): Add a command-line argument to convert special macros into
-        // special operations
-
-        // Register conversions
-
-        // Mark expansions of get_user(), offsetof() and container_of() as
-        // illegal
-        mlir::ConversionTarget trg(*mctx);
-        trg.addDynamicallyLegalOp<macroni::macroni::MacroExpansion>(
-            [](Op *op) {
-                using ME = macroni::macroni::MacroExpansion;
-                ME exp = mlir::dyn_cast<ME>(op);
-                bool has_results = !exp.getResultTypes().empty();
-                llvm::StringRef macro_name = exp.getMacroName();
-                size_t num_params = exp.getParameterNames().size();
-                bool is_get_user = (has_results &&
-                                    num_params == 2 &&
-                                    macro_name == get_user),
-                    is_offsetof = (has_results &&
-                                   num_params == 2 &&
-                                   macro_name == offsetof),
-                    is_container_of = (has_results &&
-                                       num_params == 3 &&
-                                       macro_name == container_of),
-                    is_rcu_dereference = (has_results &&
-                                          num_params == 1 &&
-                                          macro_name == rcu_dereference),
-                    //   NOTE(bpp): The actual smp_mb() macro may not have
-                    //   results! This check will need to be updated if so.
-                    is_smp_mb = (has_results &&
-                                 num_params == 0 &&
-                                 macro_name == smp_mb);
-
-                using MP = macroni::macroni::MacroParameter;
-                using RMO = vast::hl::RecordMemberOp;
-                using PT = vast::hl::PointerType;
-                using TA = mlir::TypeAttr;
-                if (is_get_user) {
-                    exp.getExpansion().walk([&](Op *cur) {
-                        if (auto param_op = mlir::dyn_cast<MP>(cur)) {
-                            auto param_name = param_op.getParameterName();
-                            if (param_name == "x") {
-                                get_user_to_x.insert({ op, cur });
-                            } else if (param_name == "ptr") {
-                                get_user_to_ptr.insert({ op, cur });
-                            }
-                        }});
-                    bool found_op = get_user_to_x.contains(op),
-                        found_ptr = get_user_to_ptr.contains(op),
-                        is_legal = !(found_op && found_ptr);
-                    return is_legal;
-                } else if (is_offsetof) {
-                    exp.getExpansion().walk([&](Op *cur) {
-                        if (auto member_op = mlir::dyn_cast<RMO>(cur)) {
-                            mlir::Value record = member_op.getRecord();
-                            mlir::Type record_ty = record.getType();
-                            if (auto pty = mlir::dyn_cast<PT>(record_ty)) {
-                                mlir::Type element_ty = pty.getElementType();
-                                auto ty_attr = TA::get(element_ty);
-                                offsetof_to_type.insert({ op, ty_attr });
-                            } else {
-                                auto ty_attr = TA::get(record_ty);
-                                offsetof_to_type.insert({ op, ty_attr });
-                            }
-                            mlir::StringAttr name = member_op.getNameAttr();
-                            offsetof_to_member[op] = name;
-                        }});
-                    bool found_type = offsetof_to_type.contains(op),
-                        found_member = offsetof_to_member.contains(op),
-                        is_legal = !(found_type && found_member);
-                    return is_legal;
-                } else if (is_container_of) {
-                    exp.getExpansion().walk([&](Op *cur) {
-                        if (auto param = mlir::dyn_cast<MP>(cur)) {
-                            auto param_name = param.getParameterName();
-                            if ("ptr" == param_name) {
-                                container_of_to_ptr.insert({ op, cur });
-                            }
-                        } else if (auto mem_op = mlir::dyn_cast<RMO>(cur)) {
-                            mlir::Value record = mem_op.getRecord();
-                            mlir::Type record_ty = record.getType();
-                            if (auto pty = mlir::dyn_cast<PT>(record_ty)) {
-                                mlir::Type elem_ty = pty.getElementType();
-                                TA ty_attr = TA::get(elem_ty);
-                                container_of_to_type.insert({ op, ty_attr });
-                            } else {
-                                TA ty_attr = TA::get(record_ty);
-                                container_of_to_type.insert({ op, ty_attr });
-                            }
-                            mlir::StringAttr mem_name = mem_op.getNameAttr();
-                            container_of_to_member.insert({ op, mem_name });
-                        }});
-                    bool found_ptr = container_of_to_ptr.contains(op),
-                        found_type = container_of_to_type.contains(op),
-                        found_member = container_of_to_member.contains(op),
-                        is_legal = !(found_ptr && found_type && found_member);
-                    return is_legal;
-                } else if (is_rcu_dereference) {
-                    exp.getExpansion().walk([&](Op *cur) {
-                        if (auto param = mlir::dyn_cast<MP>(cur)) {
-                            auto param_name = param.getParameterName();
-                            if (param_name == "p") {
-                                rcu_dereference_to_p.insert({ op, cur });
-                            }
-                        }});
-                    bool found_p = rcu_dereference_to_p.contains(op),
-                        is_legal = !found_p;
-                    return is_legal;
-                } else if (is_smp_mb) {
-                    return false;
-                } else {
-                    return true;
-                }
-            });
-        trg.addDynamicallyLegalOp<vast::hl::ForOp>(
-            [](Op *op) {
-                auto for_op = mlir::dyn_cast<vast::hl::ForOp>(op);
-                using MP = macroni::macroni::MacroParameter;
-                for_op.getCondRegion().walk(
-                    [&](Op *op2) {
-                        if (auto param_op = mlir::dyn_cast<MP>(op2)) {
-                            if (param_op.getParameterName() == "pos") {
-                                list_for_each_to_pos[op] = op2;
-                            } else if (param_op.getParameterName() == "head") {
-                                list_for_each_to_head[op] = op2;
-                            }
-                        }
-                    }
-                );
-                return !(list_for_each_to_pos.contains(op) &&
-                         list_for_each_to_head.contains(op));
-            });
-        trg.addDynamicallyLegalOp<vast::hl::CallOp>(
-            [](Op *op) {
-                using CO = vast::hl::CallOp;
-                CO call_op = mlir::dyn_cast<CO>(op);
-                llvm::StringRef name = call_op.getCalleeAttr().getValue();
-                if (rcu_read_unlock != name) {
-                    return true;
-                }
-                llvm::APInt unlock_level = get_lock_level(op);
-                for (auto cur = op; cur; cur = cur->getPrevNode()) {
-                    if (CO call_op = mlir::dyn_cast<CO>(cur)) {
-                        name = call_op.getCalleeAttr().getValue();
-                        if (rcu_read_lock == name) {
-                            llvm::APInt lock_level = get_lock_level(cur);
-                            if (unlock_level == lock_level) {
-                                unlock_to_lock[op] = cur;
-                                break;
-                            }
-                        }
-                    }
-                }
-                return !unlock_to_lock.contains(op);
-            });
-        trg.markUnknownOpDynamicallyLegal([](Op *op) { return true;});
-
-        mlir::RewritePatternSet patterns(&*mctx);
-        patterns.add<macroni::macro_expansion_to_get_user>(patterns.getContext());
-        patterns.add<macroni::macro_expansion_to_offsetof>(patterns.getContext());
-        patterns.add<macroni::macro_expansion_to_container_of>(patterns.getContext());
-        patterns.add<macroni::macro_expansion_to_rcu_dereference>(patterns.getContext());
-        patterns.add<macroni::macro_expansion_to_smp_mb>(patterns.getContext());
-        patterns.add<macroni::for_to_list_for_each>(patterns.getContext());
-        patterns.add<macroni::rcu_read_unlock_to_rcu_critical_section>(patterns.getContext());
-        Op *mod_op = mod.get().getOperation();
-        // Apply the conversions. Cast the result to void to ignore no_discard
-        // errors
-        (void) mlir::applyPartialConversion(mod_op, trg, std::move(patterns));
-
-        // Print the result
-        mlir::OpPrintingFlags flags;
-        flags.enableDebugInfo(false, true);
-        mod->print(llvm::outs(), flags);
-
-        return EXIT_SUCCESS;
     }
+
+    auto maybe_ast = pasta::parse_ast(argc, argv);
+    if (!maybe_ast.Succeeded()) {
+        std::cerr << maybe_ast.TakeError() << '\n';
+        return EXIT_FAILURE;
+    }
+    ast = maybe_ast.TakeValue();
+
+    // Register the MLIR dialects we will be lowering to
+    mlir::DialectRegistry registry;
+    registry.insert<
+        vast::hl::HighLevelDialect,
+        macroni::macroni::MacroniDialect,
+        macroni::kernel::KernelDialect
+    >();
+    auto mctx = mlir::MLIRContext(registry);
+    macroni::MacroniMetaGenerator meta(*ast, &mctx);
+    vast::cg::CodeGenBase<macroni::MacroniVisitor> codegen(&mctx, meta);
+    builder.emplace(&mctx);
+
+    // Generate the MLIR
+    codegen.append_to_module(ast->UnderlyingAST().getTranslationUnitDecl());
+    auto mod = codegen.freeze();
+
+    if (convert) {
+        // Register conversions
+        mlir::RewritePatternSet patterns(&mctx);
+        patterns.add(macroni::rewrite_get_user);
+        patterns.add(macroni::rewrite_offsetof);
+        patterns.add(macroni::rewrite_container_of);
+        patterns.add(macroni::rewrite_rcu_dereference);
+        patterns.add(macroni::rewrite_smp_mb);
+        patterns.add(macroni::rewrite_list_for_each);
+        patterns.add(macroni::rewrite_rcu_read_unlock);
+
+        // Apply the conversions.
+        mlir::FrozenRewritePatternSet frozen_pats(std::move(patterns));
+        mod->walk([&frozen_pats](mlir::Operation *op) {
+            using ME = macroni::macroni::MacroExpansion;
+            using FO = vast::hl::ForOp;
+            using CO = vast::hl::CallOp;
+            if (mlir::isa<ME, FO, CO>(op)) {
+                std::ignore = mlir::applyOpPatternsAndFold(op, frozen_pats);
+            }}
+        );
+    }
+    // Print the result
+    mod->print(llvm::outs());
+
     return EXIT_SUCCESS;
 }

--- a/bin/Macronify/ParseAST.cpp
+++ b/bin/Macronify/ParseAST.cpp
@@ -1,0 +1,42 @@
+#include "ParseAST.hpp"
+
+namespace pasta {
+    Result<AST, std::string> parse_ast(int argc, char **argv) {
+        InitPasta initializer;
+        FileManager fm(FileSystem::CreateNative());
+        auto maybe_compiler = Compiler::CreateHostCompiler(
+            fm,
+            TargetLanguage::kCXX);
+        if (!maybe_compiler.Succeeded()) {
+            return maybe_compiler.TakeError();
+        }
+
+        auto compiler = maybe_compiler.Value();
+        auto fs = FileSystem::From(compiler);
+        auto maybe_cwd = fs->CurrentWorkingDirectory();
+        if (!maybe_cwd.Succeeded()) {
+            return maybe_compiler.TakeError();
+        }
+
+        auto cwd = maybe_cwd.TakeValue();
+        const ArgumentVector args(argc - 1, &argv[1]);
+        auto maybe_command = CompileCommand::CreateFromArguments(args, cwd);
+        if (!maybe_command.Succeeded()) {
+            return std::string(maybe_command.TakeError());
+        }
+
+        const auto command = maybe_command.TakeValue();
+        auto maybe_jobs = compiler.CreateJobsForCommand(command);
+        if (!maybe_jobs.Succeeded()) {
+            return maybe_jobs.TakeError();
+        }
+
+        auto jobs = maybe_jobs.TakeValue();
+        auto maybe_ast = jobs.front().Run();
+        if (!maybe_ast.Succeeded()) {
+            return maybe_ast.TakeError();
+        }
+
+        return maybe_ast.TakeValue();
+    }
+} // namespace pasta

--- a/bin/Macronify/ParseAST.hpp
+++ b/bin/Macronify/ParseAST.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <pasta/AST/AST.h>
+#include <pasta/Compile/Command.h>
+#include <pasta/Compile/Compiler.h>
+#include <pasta/Util/ArgumentVector.h>
+#include <pasta/Util/FileSystem.h>
+#include <pasta/Util/Init.h>
+
+namespace pasta {
+    Result<AST, std::string> parse_ast(int argc, char **argv);
+} // namespace pasta

--- a/lib/macroni/Dialect/Kernel/CMakeLists.txt
+++ b/lib/macroni/Dialect/Kernel/CMakeLists.txt
@@ -20,9 +20,6 @@ add_mlir_dialect_library(MLIRKernel
         MLIRControlFlowInterfaces
         MLIRDataLayoutInterfaces
         MLIRInferTypeOpInterface
-
-        VASTSymbolInterface
-        VASTTypeQualifiersInterfaces
 )
 
 target_link_libraries(MLIRKernel PRIVATE macroni)

--- a/lib/macroni/Dialect/Macroni/CMakeLists.txt
+++ b/lib/macroni/Dialect/Macroni/CMakeLists.txt
@@ -20,9 +20,6 @@ add_mlir_dialect_library(MLIRMacroni
         MLIRControlFlowInterfaces
         MLIRDataLayoutInterfaces
         MLIRInferTypeOpInterface
-
-        VASTSymbolInterface
-        VASTTypeQualifiersInterfaces
 )
 
 target_link_libraries(MLIRMacroni PRIVATE macroni)

--- a/test/KernelTests/container_of.c
+++ b/test/KernelTests/container_of.c
@@ -1,4 +1,4 @@
-// RUN: macronify %s | FileCheck %s --match-full-lines
+// RUN: macronify -xc %s --convert | FileCheck %s --match-full-lines
 
 // CHECK: hl.translation_unit {
 // CHECK:   hl.typedef "__int128_t" : !hl.int128

--- a/test/KernelTests/get_user.c
+++ b/test/KernelTests/get_user.c
@@ -1,4 +1,4 @@
-// RUN: macronify %s | FileCheck %s --match-full-lines
+// RUN: macronify -xc %s --convert | FileCheck %s --match-full-lines
 
 // CHECK: hl.translation_unit {
 // CHECK:   hl.typedef "__int128_t" : !hl.int128

--- a/test/KernelTests/list_for_each.c
+++ b/test/KernelTests/list_for_each.c
@@ -1,4 +1,4 @@
-// RUN: macronify %s | FileCheck %s --match-full-lines
+// RUN: macronify -xc %s --convert | FileCheck %s --match-full-lines
 
 // CHECK: hl.translation_unit {
 // CHECK:   hl.typedef "__int128_t" : !hl.int128

--- a/test/KernelTests/offsetof.c
+++ b/test/KernelTests/offsetof.c
@@ -1,4 +1,4 @@
-// RUN: macronify %s | FileCheck %s --match-full-lines
+// RUN: macronify -xc %s --convert | FileCheck %s --match-full-lines
 
 // CHECK: hl.translation_unit {
 // CHECK:   hl.typedef "__int128_t" : !hl.int128

--- a/test/KernelTests/rcu_dereference.c
+++ b/test/KernelTests/rcu_dereference.c
@@ -1,4 +1,4 @@
-// RUN: macronify %s | FileCheck %s --match-full-lines
+// RUN: macronify -xc %s --convert | FileCheck %s --match-full-lines
 
 // CHECK: hl.translation_unit {
 // CHECK:   hl.typedef "__int128_t" : !hl.int128
@@ -38,7 +38,10 @@
 // CHECK:         %4 = macroni.expansion "deref(p)" : !hl.lvalue<!hl.int> {
 // CHECK:           %6 = hl.expr : !hl.lvalue<!hl.int> {
 // CHECK:             %7 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
-// CHECK:               %9 = hl.ref %0 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:               %9 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:                 %10 = hl.ref %0 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:                 hl.value.yield %10 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:               }
 // CHECK:               hl.value.yield %9 : !hl.lvalue<!hl.ptr<!hl.int>>
 // CHECK:             }
 // CHECK:             %8 = kernel.rcu_dereference rcu_dereference(%7) : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.int>

--- a/test/KernelTests/rcu_read_lock_unlock.c
+++ b/test/KernelTests/rcu_read_lock_unlock.c
@@ -1,4 +1,4 @@
-// RUN: macronify %s | FileCheck %s --match-full-lines
+// RUN: macronify -xc %s --convert | FileCheck %s --match-full-lines
 
 // CHECK: hl.translation_unit {
 // CHECK:   hl.typedef "__int128_t" : !hl.int128

--- a/test/KernelTests/smp_mb.c
+++ b/test/KernelTests/smp_mb.c
@@ -1,4 +1,4 @@
-// RUN: macronify %s | FileCheck %s --match-full-lines
+// RUN: macronify -xc %s --convert | FileCheck %s --match-full-lines
 
 // CHECK: hl.translation_unit {
 // CHECK:   hl.typedef "__int128_t" : !hl.int128

--- a/test/MacroniTests/function_like.c
+++ b/test/MacroniTests/function_like.c
@@ -1,4 +1,4 @@
-// RUN: macronify %s | FileCheck %s --match-full-lines
+// RUN: macronify -xc %s | FileCheck %s --match-full-lines
 
 //CHECK: hl.translation_unit {
 //CHECK:   hl.typedef "__int128_t" : !hl.int128

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -45,13 +45,14 @@ config.test_source_root = os.path.dirname(__file__)
 
 # test_exec_root: The root path where tests should be run.
 config.test_exec_root = os.path.join(config.macroni_obj_root, 'test')
+# TODO: Enable testing of Debug, Release, and RelWithDebInfo builds
 config.macroni_tools_dir = os.path.join(config.macroni_obj_root, 'bin')
 
 tools = [
     ToolSubst(
         "macronify",
-        os.path.join(config.macroni_obj_root, 'bin', 'Macronify', 'macronify'),
-        extra_args=["-x", "c"]),
+        os.path.join(config.macroni_obj_root, 'bin',
+                     'Macronify', 'RelWithDebInfo', 'macronify')),
 
     ToolSubst(
         "FileCheck",


### PR DESCRIPTION
In this series of commits:
- Move most declarations and definitions outside of `Main.cpp`
- Switch from using a dialect conversion driver to a greedy pattern rewrite driver to apply rewrites.
- Add a command line argument for whether or not to convert operations to kernel operations.
- Update tests.
- Extract various pieces of logic into functions to improve code legibility.