### PR TITLE
Update submodules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,8 +201,6 @@ target_link_libraries(macroni_settings
 
     gap::gap
 
-    vast::util
-
     pasta
 )
 
@@ -252,26 +250,24 @@ if (MACRONI_INSTALL)
     gap-settings
     gap
 
-    vast
     vast_settings
-    vast_translation_api
-    vast_codegen
+    VASTCodeGen
+    VASTUtil
 
-    vast_conversion_all
-    vast_conversion_abi
-    vast_conversion_common
-    vast_conversion_core
-    vast_conversion_from_hl
-
-    vast_util
-
-    MLIRABI
-    MLIRCore
-    MLIRHighLevel
-    MLIRLowLevel
-    MLIRLowLevelTransforms
-    MLIRMeta
+    VASTABI
+    VASTCore
+    VASTHighLevel
+    VASTLowLevel
+    VASTMeta
+    VASTUnsupported
+    
+    VASTABIConversionPasses
+    VASTCommonConversionPasses
     VASTCoreConversionPasses
+    VASTHighLevelConversionPasses
+    VASTHighLevelTransforms
+    VASTLowLevelTransforms
+    VASTTargetLLVMIR
 
     VASTSymbolInterface
     VASTTypeQualifiersInterfaces

--- a/bin/Kernelize/CMakeLists.txt
+++ b/bin/Kernelize/CMakeLists.txt
@@ -12,7 +12,7 @@ target_link_libraries(kernelize
     kernel_conversion
 
     MLIROptLib
-    MLIRHighLevel
+    VASTHighLevel
 
     MLIRIR
     MLIRParser
@@ -22,10 +22,7 @@ target_link_libraries(kernelize
     MLIRKernel
     MLIRMacroni
 
-    vast_high_level_transforms
-    vast_conversion_from_hl
-
-    FromSourceParser
+    VASTFromSourceParser
 )
 
 mlir_check_link_libraries(kernelize)

--- a/bin/Kernelize/KernelCodeGenVisitorMixin.hpp
+++ b/bin/Kernelize/KernelCodeGenVisitorMixin.hpp
@@ -5,6 +5,7 @@
 #include <macroni/Translation/MacroniMetaGenerator.hpp>
 #include <pasta/AST/Stmt.h>
 #include <stdint.h>
+#include <vast/CodeGen/CodeGen.hpp>
 
 template <typename Derived>
 struct KernelCodeGenVisitorMixin
@@ -72,8 +73,14 @@ struct KernelCodeGenVisitorMixin
 };
 
 template<typename Derived>
-using KernelVisitorConfig = vast::cg::CodeGenFallBackVisitorMixin<Derived,
-    KernelCodeGenVisitorMixin, vast::cg::DefaultFallBackVisitorMixin>;
+using KernelVisitorConfig = vast::cg::FallBackVisitor<Derived,
+    KernelCodeGenVisitorMixin,
+    vast::cg::UnsupportedVisitor,
+    vast::cg::UnreachableVisitor
+>;
 
-using KernelVisitor = vast::cg::CodeGenVisitor<KernelVisitorConfig,
-    macroni::MacroniMetaGenerator>;
+using KernelCodeGen = vast::cg::CodeGen<
+    macroni::MacroniCodeGenContext,
+    KernelVisitorConfig,
+    macroni::MacroniMetaGenerator
+>;

--- a/bin/Kernelize/Main.cpp
+++ b/bin/Kernelize/Main.cpp
@@ -9,14 +9,13 @@
 #include <macroni/Common/ParseAST.hpp>
 #include <macroni/Conversion/Kernel/KernelRewriters.hpp>
 #include <macroni/Translation/MacroniCodeGenVisitorMixin.hpp>
-#include <macroni/Translation/MacroniMetaGenerator.hpp>
 #include <mlir/Pass/Pass.h>
 #include <mlir/Pass/PassManager.h>
 #include <mlir/Transforms/GreedyPatternRewriteDriver.h>
 #include <mlir/Transforms/Passes.h>
 #include <optional>
 #include <pasta/AST/AST.h>
-#include <vast/Translation/CodeGen.hpp>
+#include <vast/CodeGen/CodeGen.hpp>
 
 int main(int argc, char **argv) {
     auto maybe_ast = pasta::parse_ast(argc, argv);
@@ -24,7 +23,7 @@ int main(int argc, char **argv) {
         std::cerr << maybe_ast.TakeError() << '\n';
         return EXIT_FAILURE;
     }
-    auto ast = maybe_ast.TakeValue();
+    auto pasta_ast = maybe_ast.TakeValue();
 
     // Register the MLIR dialects we will be lowering to
     mlir::DialectRegistry registry;
@@ -34,12 +33,12 @@ int main(int argc, char **argv) {
         macroni::kernel::KernelDialect
     >();
     auto mctx = mlir::MLIRContext(registry);
-    macroni::MacroniMetaGenerator meta(ast, &mctx);
-    vast::cg::CodeGenContext cgctx(mctx, ast.UnderlyingAST());
-    vast::cg::CodeGenBase<KernelVisitor> codegen(cgctx, meta);
+    macroni::MacroniCodeGenContext cgctx(mctx, pasta_ast.UnderlyingAST(),
+                                         pasta_ast);
+    KernelCodeGen codegen(cgctx);
 
     // Generate the MLIR
-    auto tu_decl = ast.UnderlyingAST().getTranslationUnitDecl();
+    auto tu_decl = pasta_ast.UnderlyingAST().getTranslationUnitDecl();
     auto mod = codegen.emit_module(tu_decl);
 
     // Register conversions

--- a/bin/Macronify/CMakeLists.txt
+++ b/bin/Macronify/CMakeLists.txt
@@ -11,7 +11,7 @@ target_link_libraries(macronify
     macroni_translation_api
 
     MLIROptLib
-    MLIRHighLevel
+    VASTHighLevel
 
     MLIRIR
     MLIRParser
@@ -20,10 +20,7 @@ target_link_libraries(macronify
 
     MLIRMacroni
 
-    vast_high_level_transforms
-    vast_conversion_from_hl
-
-    FromSourceParser
+    VASTFromSourceParser
 )
 
 mlir_check_link_libraries(macronify)

--- a/bin/SafeC/CMakeLists.txt
+++ b/bin/SafeC/CMakeLists.txt
@@ -12,7 +12,7 @@ target_link_libraries(safe-c
     safety_conversion
 
     MLIROptLib
-    MLIRHighLevel
+    VASTHighLevel
 
     MLIRIR
     MLIRParser
@@ -22,10 +22,7 @@ target_link_libraries(safe-c
     MLIRMacroni
     MLIRSafety
 
-    vast_high_level_transforms
-    vast_conversion_from_hl
-
-    FromSourceParser
+    VASTFromSourceParser
 )
 
 mlir_check_link_libraries(safe-c)

--- a/bin/SafeC/Main.cpp
+++ b/bin/SafeC/Main.cpp
@@ -9,14 +9,13 @@
 #include <macroni/Common/ParseAST.hpp>
 #include <macroni/Conversion/Safety/SafetyRewriters.hpp>
 #include <macroni/Translation/MacroniCodeGenVisitorMixin.hpp>
-#include <macroni/Translation/MacroniMetaGenerator.hpp>
 #include <mlir/Pass/Pass.h>
 #include <mlir/Pass/PassManager.h>
 #include <mlir/Transforms/GreedyPatternRewriteDriver.h>
 #include <mlir/Transforms/Passes.h>
 #include <optional>
 #include <pasta/AST/AST.h>
-#include <vast/Translation/CodeGen.hpp>
+#include <vast/CodeGen/CodeGen.hpp>
 
 int main(int argc, char **argv) {
     auto maybe_ast = pasta::parse_ast(argc, argv);
@@ -24,7 +23,7 @@ int main(int argc, char **argv) {
         std::cerr << maybe_ast.TakeError() << '\n';
         return EXIT_FAILURE;
     }
-    auto ast = maybe_ast.TakeValue();
+    auto pasta_ast = maybe_ast.TakeValue();
 
     // Register the MLIR dialects we will be lowering to
     mlir::DialectRegistry registry;
@@ -34,12 +33,12 @@ int main(int argc, char **argv) {
         macroni::safety::SafetyDialect
     >();
     auto mctx = mlir::MLIRContext(registry);
-    macroni::MacroniMetaGenerator meta(ast, &mctx);
-    vast::cg::CodeGenContext cgctx(mctx, ast.UnderlyingAST());
-    vast::cg::CodeGenBase<SafeCVisitor> codegen(cgctx, meta);
+    macroni::MacroniCodeGenContext cgctx(mctx, pasta_ast.UnderlyingAST(),
+                                         pasta_ast);
+    SafeCCodeGen codegen(cgctx);
 
     // Generate the MLIR
-    auto tu_decl = ast.UnderlyingAST().getTranslationUnitDecl();
+    auto tu_decl = pasta_ast.UnderlyingAST().getTranslationUnitDecl();
     auto mod = codegen.emit_module(tu_decl);
 
     // Register conversions

--- a/bin/SafeC/SafeCCodeGenVisitorMixin.hpp
+++ b/bin/SafeC/SafeCCodeGenVisitorMixin.hpp
@@ -5,6 +5,7 @@
 #include <macroni/Translation/MacroniMetaGenerator.hpp>
 #include <pasta/AST/Macro.h>
 #include <pasta/AST/Stmt.h>
+#include <vast/CodeGen/CodeGen.hpp>
 
 template <typename Derived>
 struct SafeCCodeGenVisitorMixin
@@ -60,8 +61,14 @@ struct SafeCCodeGenVisitorMixin
 };
 
 template<typename Derived>
-using SafeCVisitorConfig = vast::cg::CodeGenFallBackVisitorMixin<Derived,
-    SafeCCodeGenVisitorMixin, vast::cg::DefaultFallBackVisitorMixin>;
+using SafeCVisitorConfig = vast::cg::FallBackVisitor<Derived,
+    SafeCCodeGenVisitorMixin,
+    vast::cg::UnsupportedVisitor,
+    vast::cg::UnreachableVisitor
+>;
 
-using SafeCVisitor = vast::cg::CodeGenVisitor<SafeCVisitorConfig,
-    macroni::MacroniMetaGenerator>;
+using SafeCCodeGen = vast::cg::CodeGen<
+    macroni::MacroniCodeGenContext,
+    SafeCVisitorConfig,
+    macroni::MacroniMetaGenerator
+>;

--- a/include/macroni/Translation/MacroniCodeGenContext.hpp
+++ b/include/macroni/Translation/MacroniCodeGenContext.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <pasta/AST/AST.h>
+#include <vast/CodeGen/CodeGenContext.hpp>
+
+namespace macroni
+{
+    struct MacroniCodeGenContext : vast::cg::CodeGenContext {
+        pasta::AST &pasta_ast;
+
+        MacroniCodeGenContext(mlir::MLIRContext &mctx,
+                              clang::ASTContext &actx,
+                              pasta::AST &pasta_ast)
+            : CodeGenContext(mctx, actx,
+                             vast::cg::detail::create_module(mctx, actx)),
+                             pasta_ast(pasta_ast)
+        {}
+
+    };
+} // namespace macroni

--- a/include/macroni/Translation/MacroniMetaGenerator.hpp
+++ b/include/macroni/Translation/MacroniMetaGenerator.hpp
@@ -2,11 +2,11 @@
 
 #include <pasta/AST/AST.h>
 #include <pasta/AST/Macro.h>
-#include <vast/Translation/CodeGenMeta.hpp>
+#include <vast/CodeGen/CodeGenMeta.hpp>
 
 namespace macroni {
     struct MacroniMetaGenerator {
-        MacroniMetaGenerator(const pasta::AST &ast, mlir::MLIRContext *mctx)
+        MacroniMetaGenerator(clang::ASTContext *ast, mlir::MLIRContext *mctx)
             : ast(ast), mctx(mctx) {}
 
         vast::cg::DefaultMeta get(const clang::FullSourceLoc &loc) const {
@@ -21,7 +21,7 @@ namespace macroni {
         }
 
         vast::cg::DefaultMeta get(const clang::SourceLocation &loc) const {
-            clang::SourceManager &sm = ast.UnderlyingAST().getSourceManager();
+            clang::SourceManager &sm = ast->getSourceManager();
             return get(clang::FullSourceLoc(loc, sm));
         }
 
@@ -62,7 +62,7 @@ namespace macroni {
             return get(spec.getBeginLoc());
         }
 
-        const pasta::AST &ast;
+        clang::ASTContext *ast;
         mlir::MLIRContext *mctx;
     };
 } // namespace macroni

--- a/lib/macroni/Conversion/Kernel/CMakeLists.txt
+++ b/lib/macroni/Conversion/Kernel/CMakeLists.txt
@@ -4,8 +4,6 @@ add_library(kernel_conversion
 
 target_link_libraries(kernel_conversion
   PRIVATE
-    MLIRLowLevel
-    MLIRHighLevel
     MLIRIR
     MLIRPass
     MLIRTransformUtils

--- a/lib/macroni/Conversion/Safety/CMakeLists.txt
+++ b/lib/macroni/Conversion/Safety/CMakeLists.txt
@@ -4,8 +4,6 @@ add_library(safety_conversion
 
 target_link_libraries(safety_conversion
   PRIVATE
-    MLIRLowLevel
-    MLIRHighLevel
     MLIRIR
     MLIRPass
     MLIRTransformUtils

--- a/lib/macroni/Translation/CMakeLists.txt
+++ b/lib/macroni/Translation/CMakeLists.txt
@@ -8,8 +8,6 @@ target_link_libraries(macroni_translation_api
     clangASTMatchers
     clangBasic
 
-    MLIRMeta
-    MLIRHighLevel
     MLIRSupport
 
     macroni::settings

--- a/test/KernelTests/container_of.c
+++ b/test/KernelTests/container_of.c
@@ -28,7 +28,7 @@
 // CHECK:     hl.scope {
 // CHECK:       %0 = hl.var "container_instance" : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"container">>>>
 // CHECK:       %1 = macroni.parameter "ptr" : !hl.ptr<!hl.ptr<!hl.elaborated<!hl.record<"contained">>>> {
-// CHECK:         %4 = hl.ref %0 : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"container">>>>
+// CHECK:         %4 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"container">>>>) -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"container">>>>
 // CHECK:         %5 = hl.implicit_cast %4 LValueToRValue : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"container">>>> -> !hl.ptr<!hl.elaborated<!hl.record<"container">>>
 // CHECK:         %6 = hl.member %5 at "contained_member" : !hl.ptr<!hl.elaborated<!hl.record<"container">>> -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"contained">>>>
 // CHECK:         %7 = hl.addressof %6 : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"contained">>>> -> !hl.ptr<!hl.ptr<!hl.elaborated<!hl.record<"contained">>>>

--- a/test/KernelTests/get_user.c
+++ b/test/KernelTests/get_user.c
@@ -19,19 +19,21 @@
 // CHECK:   }
 // CHECK:   hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
 // CHECK:   hl.func external @main () -> !hl.int {
-// CHECK:     %0 = hl.var "x" : !hl.lvalue<!hl.int>
-// CHECK:     %1 = hl.var "ptr" : !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:     %2 = macroni.parameter "x" : !hl.lvalue<!hl.int> {
-// CHECK:       %6 = hl.ref %0 : !hl.lvalue<!hl.int>
-// CHECK:       hl.value.yield %6 : !hl.lvalue<!hl.int>
+// CHECK:     hl.scope {
+// CHECK:       %0 = hl.var "x" : !hl.lvalue<!hl.int>
+// CHECK:       %1 = hl.var "ptr" : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:       %2 = macroni.parameter "x" : !hl.lvalue<!hl.int> {
+// CHECK:         %6 = hl.ref %0 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
+// CHECK:         hl.value.yield %6 : !hl.lvalue<!hl.int>
+// CHECK:       }
+// CHECK:       %3 = macroni.parameter "ptr" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:         %6 = hl.ref %1 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:         hl.value.yield %6 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:       }
+// CHECK:       %4 = kernel.get_user get_user(%2, %3) : (!hl.lvalue<!hl.int>, !hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.int
+// CHECK:       %5 = hl.const #hl.integer<0> : !hl.int
+// CHECK:       hl.return %5 : !hl.int
 // CHECK:     }
-// CHECK:     %3 = macroni.parameter "ptr" : !hl.lvalue<!hl.ptr<!hl.int>> {
-// CHECK:       %6 = hl.ref %1 : !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:       hl.value.yield %6 : !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:     }
-// CHECK:     %4 = kernel.get_user get_user(%2, %3) : (!hl.lvalue<!hl.int>, !hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.int
-// CHECK:     %5 = hl.const #hl.integer<0> : !hl.int
-// CHECK:     hl.return %5 : !hl.int
 // CHECK:   }
 // CHECK: }
 

--- a/test/KernelTests/list_for_each.c
+++ b/test/KernelTests/list_for_each.c
@@ -25,9 +25,9 @@
 // CHECK:   }
 // CHECK:   hl.func internal @list_is_head (%arg0: !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>>, %arg1: !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>>) -> !hl.int attributes {sym_visibility = "private"} {
 // CHECK:     hl.scope {
-// CHECK:       %0 = hl.ref %arg0 : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>>
+// CHECK:       %0 = hl.ref %arg0 : (!hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>>) -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>>
 // CHECK:       %1 = hl.implicit_cast %0 LValueToRValue : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>> -> !hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>
-// CHECK:       %2 = hl.ref %arg1 : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>>
+// CHECK:       %2 = hl.ref %arg1 : (!hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>>) -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>>
 // CHECK:       %3 = hl.implicit_cast %2 LValueToRValue : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>> -> !hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>
 // CHECK:       %4 = hl.cmp eq %1, %3 : !hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>, !hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >> -> !hl.int
 // CHECK:       hl.return %4 : !hl.int
@@ -39,12 +39,12 @@
 // CHECK:       %1 = hl.var "pos" : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
 // CHECK:       hl.scope {
 // CHECK:         %3 = macroni.parameter "pos" : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>> {
-// CHECK:           %11 = hl.ref %1 : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
+// CHECK:           %11 = hl.ref %1 : (!hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>) -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
 // CHECK:           hl.value.yield %11 : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
 // CHECK:         }
 // CHECK:         %4 = hl.expr : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>> {
 // CHECK:           %11 = macroni.parameter "head" : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>> {
-// CHECK:             %12 = hl.ref %0 : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
+// CHECK:             %12 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>) -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
 // CHECK:             hl.value.yield %12 : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
 // CHECK:           }
 // CHECK:           hl.value.yield %11 : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
@@ -54,17 +54,17 @@
 // CHECK:         %7 = hl.implicit_cast %6 LValueToRValue : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>> -> !hl.ptr<!hl.elaborated<!hl.record<"list_head">>>
 // CHECK:         %8 = hl.assign %7 to %3 : !hl.ptr<!hl.elaborated<!hl.record<"list_head">>>, !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>> -> !hl.ptr<!hl.elaborated<!hl.record<"list_head">>>
 // CHECK:         %9 = macroni.parameter "pos" : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>> {
-// CHECK:           %11 = hl.ref %1 : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
+// CHECK:           %11 = hl.ref %1 : (!hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>) -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
 // CHECK:           hl.value.yield %11 : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
 // CHECK:         }
 // CHECK:         %10 = macroni.parameter "head" : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>> {
-// CHECK:           %11 = hl.ref %0 : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
+// CHECK:           %11 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>) -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
 // CHECK:           hl.value.yield %11 : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
 // CHECK:         }
 // CHECK:         kernel.list_for_each() list_for_each(%9, %10) : (!hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>, !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>) -> () {
 // CHECK:           hl.scope {
 // CHECK:             %11 = hl.var "prev" : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>> = {
-// CHECK:               %12 = hl.ref %1 : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
+// CHECK:               %12 = hl.ref %1 : (!hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>) -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
 // CHECK:               %13 = hl.implicit_cast %12 LValueToRValue : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>> -> !hl.ptr<!hl.elaborated<!hl.record<"list_head">>>
 // CHECK:               %14 = hl.member %13 at "prev" : !hl.ptr<!hl.elaborated<!hl.record<"list_head">>> -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
 // CHECK:               %15 = hl.implicit_cast %14 LValueToRValue : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>> -> !hl.ptr<!hl.elaborated<!hl.record<"list_head">>>

--- a/test/KernelTests/rcu_dereference.c
+++ b/test/KernelTests/rcu_dereference.c
@@ -27,7 +27,7 @@
 // CHECK:       }
 // CHECK:       %1 = hl.var "x" : !hl.lvalue<!hl.int> = {
 // CHECK:         %4 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
-// CHECK:           %7 = hl.ref %0 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:           %7 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
 // CHECK:           hl.value.yield %7 : !hl.lvalue<!hl.ptr<!hl.int>>
 // CHECK:         }
 // CHECK:         %5 = kernel.rcu_dereference rcu_dereference(%4) : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.int>
@@ -39,7 +39,7 @@
 // CHECK:           %6 = hl.expr : !hl.lvalue<!hl.int> {
 // CHECK:             %7 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
 // CHECK:               %9 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
-// CHECK:                 %10 = hl.ref %0 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:                 %10 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
 // CHECK:                 hl.value.yield %10 : !hl.lvalue<!hl.ptr<!hl.int>>
 // CHECK:               }
 // CHECK:               hl.value.yield %9 : !hl.lvalue<!hl.ptr<!hl.int>>

--- a/test/KernelTests/rcu_read_lock_unlock.c
+++ b/test/KernelTests/rcu_read_lock_unlock.c
@@ -55,17 +55,17 @@
 // CHECK:       }
 // CHECK:       kernel.rcu.critical_section {
 // CHECK:         hl.scope {
-// CHECK:           %2 = hl.ref %0 : !hl.lvalue<!hl.int>
+// CHECK:           %2 = hl.ref %0 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
 // CHECK:           %3 = hl.const #hl.integer<0> : !hl.int
 // CHECK:           %4 = hl.assign %3 to %2 : !hl.int, !hl.lvalue<!hl.int> -> !hl.int
 // CHECK:           hl.for {
-// CHECK:             %5 = hl.ref %0 : !hl.lvalue<!hl.int>
+// CHECK:             %5 = hl.ref %0 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
 // CHECK:             %6 = hl.implicit_cast %5 LValueToRValue : !hl.lvalue<!hl.int> -> !hl.int
 // CHECK:             %7 = hl.const #hl.integer<10> : !hl.int
 // CHECK:             %8 = hl.cmp slt %6, %7 : !hl.int, !hl.int -> !hl.int
 // CHECK:             hl.cond.yield %8 : !hl.int
 // CHECK:           } incr {
-// CHECK:             %5 = hl.ref %0 : !hl.lvalue<!hl.int>
+// CHECK:             %5 = hl.ref %0 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
 // CHECK:             %6 = hl.post.inc %5 : !hl.lvalue<!hl.int> -> !hl.int
 // CHECK:           } do {
 // CHECK:             hl.scope {

--- a/test/MacroniTests/function_like.c
+++ b/test/MacroniTests/function_like.c
@@ -379,7 +379,7 @@
 // CHECK:         hl.do {
 // CHECK:           hl.scope {
 // CHECK:             %16 = macroni.parameter "STMT" : !hl.int {
-// CHECK:               %17 = hl.ref %14 : !hl.lvalue<!hl.int>
+// CHECK:               %17 = hl.ref %14 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
 // CHECK:               %18 = hl.const #hl.integer<0> : !hl.int
 // CHECK:               %19 = hl.assign %18 to %17 : !hl.int, !hl.lvalue<!hl.int> -> !hl.int
 // CHECK:               hl.value.yield %19 : !hl.int
@@ -398,7 +398,7 @@
 // CHECK:                 hl.do {
 // CHECK:                   hl.scope {
 // CHECK:                     %16 = macroni.parameter "STMT" : !hl.int {
-// CHECK:                       %17 = hl.ref %14 : !hl.lvalue<!hl.int>
+// CHECK:                       %17 = hl.ref %14 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
 // CHECK:                       %18 = hl.const #hl.integer<0> : !hl.int
 // CHECK:                       %19 = hl.assign %18 to %17 : !hl.int, !hl.lvalue<!hl.int> -> !hl.int
 // CHECK:                       hl.value.yield %19 : !hl.int
@@ -420,7 +420,7 @@
 // CHECK:         hl.do {
 // CHECK:           hl.scope {
 // CHECK:             %16 = macroni.parameter "STMT" : !hl.int {
-// CHECK:               %17 = hl.ref %14 : !hl.lvalue<!hl.int>
+// CHECK:               %17 = hl.ref %14 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
 // CHECK:               %18 = hl.const #hl.integer<1> : !hl.int
 // CHECK:               %19 = hl.assign %18 to %17 : !hl.int, !hl.lvalue<!hl.int> -> !hl.int
 // CHECK:               hl.value.yield %19 : !hl.int
@@ -437,7 +437,7 @@
 // CHECK:             hl.do {
 // CHECK:               hl.scope {
 // CHECK:                 %16 = macroni.parameter "STMT" : !hl.int {
-// CHECK:                   %17 = hl.ref %14 : !hl.lvalue<!hl.int>
+// CHECK:                   %17 = hl.ref %14 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
 // CHECK:                   %18 = hl.const #hl.integer<1> : !hl.int
 // CHECK:                   %19 = hl.assign %18 to %17 : !hl.int, !hl.lvalue<!hl.int> -> !hl.int
 // CHECK:                   hl.value.yield %19 : !hl.int
@@ -458,6 +458,7 @@
 // CHECK:       hl.return %15 : !hl.int
 // CHECK:     }
 // CHECK:   }
+// CHECK: }
 
 
 #define ONE 1


### PR DESCRIPTION
- Updates Macroni's VAST and PASTA submodules.
- Updates Macroni's CMake to accommodate VAST's new CMake structure and naming.
- Updates Macroni's binaries to use VAST's new CodeGen API.
- Updates Macroni's tests to reflect change in VAST's HighLevel output (e.g., for calls to typeof).