### PR TITLE
Update tests

### DIFF
--- a/test/KernelTests/container_of.c
+++ b/test/KernelTests/container_of.c
@@ -24,8 +24,8 @@
 // CHECK:   hl.struct "container" : {
 // CHECK:     hl.field "contained_member" : !hl.ptr<!hl.elaborated<!hl.record<"contained">>>
 // CHECK:   }
-// CHECK:   hl.func external @main () -> !hl.int {
-// CHECK:     hl.scope {
+// CHECK:   hl.func @main () -> !hl.int {
+// CHECK:     core.scope {
 // CHECK:       %0 = hl.var "container_instance" : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"container">>>>
 // CHECK:       %1 = macroni.parameter "ptr" : !hl.ptr<!hl.ptr<!hl.elaborated<!hl.record<"contained">>>> {
 // CHECK:         %4 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"container">>>>) -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"container">>>>
@@ -35,11 +35,12 @@
 // CHECK:         hl.value.yield %7 : !hl.ptr<!hl.ptr<!hl.elaborated<!hl.record<"contained">>>>
 // CHECK:       }
 // CHECK:       %2 = kernel.container_of container_of(%1, !hl.elaborated<!hl.record<"container">>, "contained_member") : (!hl.ptr<!hl.ptr<!hl.elaborated<!hl.record<"contained">>>>) -> !hl.ptr<!hl.elaborated<!hl.record<"container">>>
-// CHECK:       %3 = hl.const #hl.integer<0> : !hl.int
+// CHECK:       %3 = hl.const #core.integer<0> : !hl.int
 // CHECK:       hl.return %3 : !hl.int
 // CHECK:     }
 // CHECK:   }
 // CHECK: }
+
 
 typedef unsigned long size_t;
 

--- a/test/KernelTests/get_user.c
+++ b/test/KernelTests/get_user.c
@@ -18,8 +18,8 @@
 // CHECK:     hl.field "reg_save_area" : !hl.ptr<!hl.void>
 // CHECK:   }
 // CHECK:   hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
-// CHECK:   hl.func external @main () -> !hl.int {
-// CHECK:     hl.scope {
+// CHECK:   hl.func @main () -> !hl.int {
+// CHECK:     core.scope {
 // CHECK:       %0 = hl.var "x" : !hl.lvalue<!hl.int>
 // CHECK:       %1 = hl.var "ptr" : !hl.lvalue<!hl.ptr<!hl.int>>
 // CHECK:       %2 = macroni.parameter "x" : !hl.lvalue<!hl.int> {
@@ -31,7 +31,7 @@
 // CHECK:         hl.value.yield %6 : !hl.lvalue<!hl.ptr<!hl.int>>
 // CHECK:       }
 // CHECK:       %4 = kernel.get_user get_user(%2, %3) : (!hl.lvalue<!hl.int>, !hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.int
-// CHECK:       %5 = hl.const #hl.integer<0> : !hl.int
+// CHECK:       %5 = hl.const #core.integer<0> : !hl.int
 // CHECK:       hl.return %5 : !hl.int
 // CHECK:     }
 // CHECK:   }

--- a/test/KernelTests/list_for_each.c
+++ b/test/KernelTests/list_for_each.c
@@ -23,8 +23,8 @@
 // CHECK:     hl.field "next" : !hl.ptr<!hl.elaborated<!hl.record<"list_head">>>
 // CHECK:     hl.field "prev" : !hl.ptr<!hl.elaborated<!hl.record<"list_head">>>
 // CHECK:   }
-// CHECK:   hl.func internal @list_is_head (%arg0: !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>>, %arg1: !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>>) -> !hl.int attributes {sym_visibility = "private"} {
-// CHECK:     hl.scope {
+// CHECK:   hl.func @list_is_head internal (%arg0: !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>>, %arg1: !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>>) -> !hl.int attributes {sym_visibility = "private"} {
+// CHECK:     core.scope {
 // CHECK:       %0 = hl.ref %arg0 : (!hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>>) -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>>
 // CHECK:       %1 = hl.implicit_cast %0 LValueToRValue : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>> -> !hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>
 // CHECK:       %2 = hl.ref %arg1 : (!hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>>) -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>>
@@ -33,11 +33,11 @@
 // CHECK:       hl.return %4 : !hl.int
 // CHECK:     }
 // CHECK:   }
-// CHECK:   hl.func external @main () -> !hl.int {
-// CHECK:     hl.scope {
+// CHECK:   hl.func @main () -> !hl.int {
+// CHECK:     core.scope {
 // CHECK:       %0 = hl.var "head" : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
 // CHECK:       %1 = hl.var "pos" : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
-// CHECK:       hl.scope {
+// CHECK:       core.scope {
 // CHECK:         %3 = macroni.parameter "pos" : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>> {
 // CHECK:           %11 = hl.ref %1 : (!hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>) -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
 // CHECK:           hl.value.yield %11 : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
@@ -62,7 +62,7 @@
 // CHECK:           hl.value.yield %11 : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
 // CHECK:         }
 // CHECK:         kernel.list_for_each() list_for_each(%9, %10) : (!hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>, !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>) -> () {
-// CHECK:           hl.scope {
+// CHECK:           core.scope {
 // CHECK:             %11 = hl.var "prev" : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>> = {
 // CHECK:               %12 = hl.ref %1 : (!hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>) -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
 // CHECK:               %13 = hl.implicit_cast %12 LValueToRValue : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>> -> !hl.ptr<!hl.elaborated<!hl.record<"list_head">>>
@@ -73,7 +73,7 @@
 // CHECK:           }
 // CHECK:         }
 // CHECK:       }
-// CHECK:       %2 = hl.const #hl.integer<0> : !hl.int
+// CHECK:       %2 = hl.const #core.integer<0> : !hl.int
 // CHECK:       hl.return %2 : !hl.int
 // CHECK:     }
 // CHECK:   }

--- a/test/KernelTests/offsetof.c
+++ b/test/KernelTests/offsetof.c
@@ -24,10 +24,10 @@
 // CHECK:     hl.field "line" : !hl.int
 // CHECK:     hl.field "col" : !hl.int
 // CHECK:   }
-// CHECK:   hl.func external @main () -> !hl.int {
-// CHECK:     hl.scope {
+// CHECK:   hl.func @main () -> !hl.int {
+// CHECK:     core.scope {
 // CHECK:       %0 = kernel.offsetof offsetof(!hl.elaborated<!hl.record<"location">>, "line") : () -> !hl.elaborated<!hl.typedef<"size_t">>
-// CHECK:       %1 = hl.const #hl.integer<0> : !hl.int
+// CHECK:       %1 = hl.const #core.integer<0> : !hl.int
 // CHECK:       hl.return %1 : !hl.int
 // CHECK:     }
 // CHECK:   }

--- a/test/KernelTests/rcu_dereference.c
+++ b/test/KernelTests/rcu_dereference.c
@@ -18,10 +18,10 @@
 // CHECK:     hl.field "reg_save_area" : !hl.ptr<!hl.void>
 // CHECK:   }
 // CHECK:   hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
-// CHECK:   hl.func external @main () -> !hl.int {
-// CHECK:     hl.scope {
+// CHECK:   hl.func @main () -> !hl.int {
+// CHECK:     core.scope {
 // CHECK:       %0 = hl.var "p" : !hl.lvalue<!hl.ptr<!hl.int>> = {
-// CHECK:         %4 = hl.const #hl.integer<12648430> : !hl.int
+// CHECK:         %4 = hl.const #core.integer<12648430> : !hl.int
 // CHECK:         %5 = hl.cstyle_cast %4 IntegralToPointer : !hl.int -> !hl.ptr<!hl.int>
 // CHECK:         hl.value.yield %5 : !hl.ptr<!hl.int>
 // CHECK:       }
@@ -52,7 +52,7 @@
 // CHECK:         %5 = hl.implicit_cast %4 LValueToRValue : !hl.lvalue<!hl.int> -> !hl.int
 // CHECK:         hl.value.yield %5 : !hl.int
 // CHECK:       }
-// CHECK:       %3 = hl.const #hl.integer<0> : !hl.int
+// CHECK:       %3 = hl.const #core.integer<0> : !hl.int
 // CHECK:       hl.return %3 : !hl.int
 // CHECK:     }
 // CHECK:   }

--- a/test/KernelTests/rcu_read_lock_unlock.c
+++ b/test/KernelTests/rcu_read_lock_unlock.c
@@ -18,75 +18,80 @@
 // CHECK:     hl.field "reg_save_area" : !hl.ptr<!hl.void>
 // CHECK:   }
 // CHECK:   hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
-// CHECK:   hl.func external @rcu_read_lock () {
-// CHECK:     hl.scope {
-// CHECK:       hl.return
+// CHECK:   hl.func @rcu_read_lock () -> !hl.void {
+// CHECK:     core.scope {
+// CHECK:       %0 = hl.const #void_value
+// CHECK:       core.implicit.return %0 : !hl.void
 // CHECK:     }
 // CHECK:   }
-// CHECK:   hl.func external @rcu_read_unlock () {
-// CHECK:     hl.scope {
-// CHECK:       hl.return
+// CHECK:   hl.func @rcu_read_unlock () -> !hl.void {
+// CHECK:     core.scope {
+// CHECK:       %0 = hl.const #void_value
+// CHECK:       core.implicit.return %0 : !hl.void
 // CHECK:     }
 // CHECK:   }
-// CHECK:   hl.func external @lock () {
-// CHECK:     hl.scope {
-// CHECK:       hl.call @rcu_read_lock() {lock_level = 0 : i64} : () -> ()
-// CHECK:       hl.return
+// CHECK:   hl.func @lock () -> !hl.void {
+// CHECK:     core.scope {
+// CHECK:       %0 = hl.call @rcu_read_lock() {lock_level = 0 : i64} : () -> !hl.void
+// CHECK:       %1 = hl.const #void_value
+// CHECK:       core.implicit.return %1 : !hl.void
 // CHECK:     }
 // CHECK:   }
-// CHECK:   hl.func external @unlock () {
-// CHECK:     hl.scope {
-// CHECK:       hl.call @rcu_read_unlock() {lock_level = 0 : i64} : () -> ()
-// CHECK:       hl.return
+// CHECK:   hl.func @unlock () -> !hl.void {
+// CHECK:     core.scope {
+// CHECK:       %0 = hl.call @rcu_read_unlock() {lock_level = 0 : i64} : () -> !hl.void
+// CHECK:       %1 = hl.const #void_value
+// CHECK:       core.implicit.return %1 : !hl.void
 // CHECK:     }
 // CHECK:   }
-// CHECK:   hl.func external @foo () {
-// CHECK:     hl.scope {
-// CHECK:       hl.return
+// CHECK:   hl.func @foo () -> !hl.void {
+// CHECK:     core.scope {
+// CHECK:       %0 = hl.const #void_value
+// CHECK:       core.implicit.return %0 : !hl.void
 // CHECK:     }
 // CHECK:   }
-// CHECK:   hl.func external @main () -> !hl.int {
-// CHECK:     hl.scope {
+// CHECK:   hl.func @main () -> !hl.int {
+// CHECK:     core.scope {
 // CHECK:       %0 = hl.var "i" : !hl.lvalue<!hl.int>
 // CHECK:       kernel.rcu.critical_section {
 // CHECK:       }
 // CHECK:       kernel.rcu.critical_section {
-// CHECK:         hl.call @foo() : () -> ()
+// CHECK:         %2 = hl.call @foo() : () -> !hl.void
 // CHECK:       }
 // CHECK:       kernel.rcu.critical_section {
-// CHECK:         hl.scope {
+// CHECK:         core.scope {
 // CHECK:           %2 = hl.ref %0 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
-// CHECK:           %3 = hl.const #hl.integer<0> : !hl.int
+// CHECK:           %3 = hl.const #core.integer<0> : !hl.int
 // CHECK:           %4 = hl.assign %3 to %2 : !hl.int, !hl.lvalue<!hl.int> -> !hl.int
 // CHECK:           hl.for {
 // CHECK:             %5 = hl.ref %0 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
 // CHECK:             %6 = hl.implicit_cast %5 LValueToRValue : !hl.lvalue<!hl.int> -> !hl.int
-// CHECK:             %7 = hl.const #hl.integer<10> : !hl.int
+// CHECK:             %7 = hl.const #core.integer<10> : !hl.int
 // CHECK:             %8 = hl.cmp slt %6, %7 : !hl.int, !hl.int -> !hl.int
 // CHECK:             hl.cond.yield %8 : !hl.int
 // CHECK:           } incr {
 // CHECK:             %5 = hl.ref %0 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
 // CHECK:             %6 = hl.post.inc %5 : !hl.lvalue<!hl.int> -> !hl.int
 // CHECK:           } do {
-// CHECK:             hl.scope {
-// CHECK:               hl.call @foo() : () -> ()
+// CHECK:             core.scope {
+// CHECK:               %5 = hl.call @foo() : () -> !hl.void
 // CHECK:             }
 // CHECK:           }
 // CHECK:         }
 // CHECK:       }
 // CHECK:       kernel.rcu.critical_section {
-// CHECK:         hl.scope {
+// CHECK:         core.scope {
 // CHECK:           kernel.rcu.critical_section {
 // CHECK:           }
 // CHECK:         }
 // CHECK:       }
 // CHECK:       kernel.rcu.critical_section {
 // CHECK:         hl.do {
-// CHECK:           hl.scope {
+// CHECK:           core.scope {
 // CHECK:             %2 = hl.var "x" : !hl.lvalue<!hl.int>
 // CHECK:           }
 // CHECK:         } while {
-// CHECK:           %2 = hl.const #hl.integer<0> : !hl.int
+// CHECK:           %2 = hl.const #core.integer<0> : !hl.int
 // CHECK:           hl.cond.yield %2 : !hl.int
 // CHECK:         }
 // CHECK:       }
@@ -100,50 +105,50 @@
 // CHECK:       }
 // CHECK:       kernel.rcu.critical_section {
 // CHECK:         hl.do {
-// CHECK:           hl.scope {
+// CHECK:           core.scope {
 // CHECK:             kernel.rcu.critical_section {
 // CHECK:               %2 = hl.var "x" : !hl.lvalue<!hl.int>
 // CHECK:             }
 // CHECK:           }
 // CHECK:         } while {
-// CHECK:           %2 = hl.const #hl.integer<0> : !hl.int
+// CHECK:           %2 = hl.const #core.integer<0> : !hl.int
 // CHECK:           hl.cond.yield %2 : !hl.int
 // CHECK:         }
 // CHECK:       }
 // CHECK:       hl.do {
-// CHECK:         hl.scope {
+// CHECK:         core.scope {
 // CHECK:           kernel.rcu.critical_section {
 // CHECK:             %2 = hl.var "x" : !hl.lvalue<!hl.int> = {
-// CHECK:               %4 = hl.const #hl.integer<1> : !hl.int
+// CHECK:               %4 = hl.const #core.integer<1> : !hl.int
 // CHECK:               hl.value.yield %4 : !hl.int
 // CHECK:             }
 // CHECK:             kernel.rcu.critical_section {
 // CHECK:             }
 // CHECK:             %3 = hl.var "y" : !hl.lvalue<!hl.int> = {
-// CHECK:               %4 = hl.const #hl.integer<2> : !hl.int
+// CHECK:               %4 = hl.const #core.integer<2> : !hl.int
 // CHECK:               hl.value.yield %4 : !hl.int
 // CHECK:             }
 // CHECK:           }
 // CHECK:         }
 // CHECK:       } while {
-// CHECK:         %2 = hl.const #hl.integer<0> : !hl.int
+// CHECK:         %2 = hl.const #core.integer<0> : !hl.int
 // CHECK:         hl.cond.yield %2 : !hl.int
 // CHECK:       }
 // CHECK:       kernel.rcu.critical_section {
 // CHECK:         hl.if {
-// CHECK:           %2 = hl.const #hl.integer<1> : !hl.int
+// CHECK:           %2 = hl.const #core.integer<1> : !hl.int
 // CHECK:           hl.cond.yield %2 : !hl.int
 // CHECK:         } then {
-// CHECK:           hl.scope {
-// CHECK:             hl.call @rcu_read_unlock() {lock_level = 0 : i64} : () -> ()
+// CHECK:           core.scope {
+// CHECK:             %2 = hl.call @rcu_read_unlock() {lock_level = 0 : i64} : () -> !hl.void
 // CHECK:           }
 // CHECK:         } else {
-// CHECK:           hl.scope {
-// CHECK:             hl.call @rcu_read_lock() {lock_level = 0 : i64} : () -> ()
+// CHECK:           core.scope {
+// CHECK:             %2 = hl.call @rcu_read_lock() {lock_level = 0 : i64} : () -> !hl.void
 // CHECK:           }
 // CHECK:         }
 // CHECK:       }
-// CHECK:       %1 = hl.const #hl.integer<0> : !hl.int
+// CHECK:       %1 = hl.const #core.integer<0> : !hl.int
 // CHECK:       hl.return %1 : !hl.int
 // CHECK:     }
 // CHECK:   }

--- a/test/KernelTests/smp_mb.c
+++ b/test/KernelTests/smp_mb.c
@@ -18,20 +18,21 @@
 // CHECK:     hl.field "reg_save_area" : !hl.ptr<!hl.void>
 // CHECK:   }
 // CHECK:   hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
-// CHECK:   hl.func external @barrier () -> !hl.int {
-// CHECK:     hl.scope {
-// CHECK:       %0 = hl.const #hl.integer<0> : !hl.int
+// CHECK:   hl.func @barrier () -> !hl.int {
+// CHECK:     core.scope {
+// CHECK:       %0 = hl.const #core.integer<0> : !hl.int
 // CHECK:       hl.return %0 : !hl.int
 // CHECK:     }
 // CHECK:   }
-// CHECK:   hl.func external @main () -> !hl.int {
-// CHECK:     hl.scope {
+// CHECK:   hl.func @main () -> !hl.int {
+// CHECK:     core.scope {
 // CHECK:       %0 = kernel.smp_mb smp_mb() : () -> !hl.int
-// CHECK:       %1 = hl.const #hl.integer<0> : !hl.int
+// CHECK:       %1 = hl.const #core.integer<0> : !hl.int
 // CHECK:       hl.return %1 : !hl.int
 // CHECK:     }
 // CHECK:   }
 // CHECK: }
+
 
 int barrier(void) { return 0; }
 #define smp_mb() barrier()

--- a/test/MacroniTests/function_like.c
+++ b/test/MacroniTests/function_like.c
@@ -20,18 +20,18 @@
 // CHECK:   hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
 // CHECK:   %0 = hl.var "a" : !hl.lvalue<!hl.int> = {
 // CHECK:     %14 = macroni.expansion "ONE" : !hl.int {
-// CHECK:       %15 = hl.const #hl.integer<1> : !hl.int
+// CHECK:       %15 = hl.const #core.integer<1> : !hl.int
 // CHECK:       hl.value.yield %15 : !hl.int
 // CHECK:     }
 // CHECK:     hl.value.yield %14 : !hl.int
 // CHECK:   }
 // CHECK:   %1 = hl.var "b" : !hl.lvalue<!hl.int> = {
 // CHECK:     %14 = macroni.expansion "ONE" : !hl.int {
-// CHECK:       %17 = hl.const #hl.integer<1> : !hl.int
+// CHECK:       %17 = hl.const #core.integer<1> : !hl.int
 // CHECK:       hl.value.yield %17 : !hl.int
 // CHECK:     }
 // CHECK:     %15 = macroni.expansion "ONE" : !hl.int {
-// CHECK:       %17 = hl.const #hl.integer<1> : !hl.int
+// CHECK:       %17 = hl.const #core.integer<1> : !hl.int
 // CHECK:       hl.value.yield %17 : !hl.int
 // CHECK:     }
 // CHECK:     %16 = hl.add %14, %15 : (!hl.int, !hl.int) -> !hl.int
@@ -40,11 +40,11 @@
 // CHECK:   %2 = hl.var "c" : !hl.lvalue<!hl.int> = {
 // CHECK:     %14 = macroni.expansion "ADD(X, Y)" : !hl.int {
 // CHECK:       %15 = macroni.parameter "X" : !hl.int {
-// CHECK:         %18 = hl.const #hl.integer<1> : !hl.int
+// CHECK:         %18 = hl.const #core.integer<1> : !hl.int
 // CHECK:         hl.value.yield %18 : !hl.int
 // CHECK:       }
 // CHECK:       %16 = macroni.parameter "Y" : !hl.int {
-// CHECK:         %18 = hl.const #hl.integer<1> : !hl.int
+// CHECK:         %18 = hl.const #core.integer<1> : !hl.int
 // CHECK:         hl.value.yield %18 : !hl.int
 // CHECK:       }
 // CHECK:       %17 = hl.add %15, %16 : (!hl.int, !hl.int) -> !hl.int
@@ -55,12 +55,12 @@
 // CHECK:   %3 = hl.var "d" : !hl.lvalue<!hl.int> = {
 // CHECK:     %14 = macroni.expansion "ADD(X, Y)" : !hl.int {
 // CHECK:       %15 = macroni.parameter "X" : !hl.int {
-// CHECK:         %18 = hl.const #hl.integer<1> : !hl.int
+// CHECK:         %18 = hl.const #core.integer<1> : !hl.int
 // CHECK:         hl.value.yield %18 : !hl.int
 // CHECK:       }
 // CHECK:       %16 = macroni.parameter "Y" : !hl.int {
 // CHECK:         %18 = macroni.expansion "ONE" : !hl.int {
-// CHECK:           %19 = hl.const #hl.integer<1> : !hl.int
+// CHECK:           %19 = hl.const #core.integer<1> : !hl.int
 // CHECK:           hl.value.yield %19 : !hl.int
 // CHECK:         }
 // CHECK:         hl.value.yield %18 : !hl.int
@@ -74,13 +74,13 @@
 // CHECK:     %14 = macroni.expansion "ADD(X, Y)" : !hl.int {
 // CHECK:       %15 = macroni.parameter "X" : !hl.int {
 // CHECK:         %18 = macroni.expansion "ONE" : !hl.int {
-// CHECK:           %19 = hl.const #hl.integer<1> : !hl.int
+// CHECK:           %19 = hl.const #core.integer<1> : !hl.int
 // CHECK:           hl.value.yield %19 : !hl.int
 // CHECK:         }
 // CHECK:         hl.value.yield %18 : !hl.int
 // CHECK:       }
 // CHECK:       %16 = macroni.parameter "Y" : !hl.int {
-// CHECK:         %18 = hl.const #hl.integer<1> : !hl.int
+// CHECK:         %18 = hl.const #core.integer<1> : !hl.int
 // CHECK:         hl.value.yield %18 : !hl.int
 // CHECK:       }
 // CHECK:       %17 = hl.add %15, %16 : (!hl.int, !hl.int) -> !hl.int
@@ -92,14 +92,14 @@
 // CHECK:     %14 = macroni.expansion "ADD(X, Y)" : !hl.int {
 // CHECK:       %15 = macroni.parameter "X" : !hl.int {
 // CHECK:         %18 = macroni.expansion "ONE" : !hl.int {
-// CHECK:           %19 = hl.const #hl.integer<1> : !hl.int
+// CHECK:           %19 = hl.const #core.integer<1> : !hl.int
 // CHECK:           hl.value.yield %19 : !hl.int
 // CHECK:         }
 // CHECK:         hl.value.yield %18 : !hl.int
 // CHECK:       }
 // CHECK:       %16 = macroni.parameter "Y" : !hl.int {
 // CHECK:         %18 = macroni.expansion "ONE" : !hl.int {
-// CHECK:           %19 = hl.const #hl.integer<1> : !hl.int
+// CHECK:           %19 = hl.const #core.integer<1> : !hl.int
 // CHECK:           hl.value.yield %19 : !hl.int
 // CHECK:         }
 // CHECK:         hl.value.yield %18 : !hl.int
@@ -114,11 +114,11 @@
 // CHECK:       %15 = macroni.parameter "X" : !hl.int {
 // CHECK:         %18 = macroni.expansion "MUL(A, B)" : !hl.int {
 // CHECK:           %19 = macroni.parameter "A" : !hl.int {
-// CHECK:             %22 = hl.const #hl.integer<1> : !hl.int
+// CHECK:             %22 = hl.const #core.integer<1> : !hl.int
 // CHECK:             hl.value.yield %22 : !hl.int
 // CHECK:           }
 // CHECK:           %20 = macroni.parameter "B" : !hl.int {
-// CHECK:             %22 = hl.const #hl.integer<2> : !hl.int
+// CHECK:             %22 = hl.const #core.integer<2> : !hl.int
 // CHECK:             hl.value.yield %22 : !hl.int
 // CHECK:           }
 // CHECK:           %21 = hl.mul %19, %20 : (!hl.int, !hl.int) -> !hl.int
@@ -127,7 +127,7 @@
 // CHECK:         hl.value.yield %18 : !hl.int
 // CHECK:       }
 // CHECK:       %16 = macroni.parameter "Y" : !hl.int {
-// CHECK:         %18 = hl.const #hl.integer<3> : !hl.int
+// CHECK:         %18 = hl.const #core.integer<3> : !hl.int
 // CHECK:         hl.value.yield %18 : !hl.int
 // CHECK:       }
 // CHECK:       %17 = hl.add %15, %16 : (!hl.int, !hl.int) -> !hl.int
@@ -138,17 +138,17 @@
 // CHECK:   %7 = hl.var "h" : !hl.lvalue<!hl.int> = {
 // CHECK:     %14 = macroni.expansion "ADD(X, Y)" : !hl.int {
 // CHECK:       %15 = macroni.parameter "X" : !hl.int {
-// CHECK:         %18 = hl.const #hl.integer<1> : !hl.int
+// CHECK:         %18 = hl.const #core.integer<1> : !hl.int
 // CHECK:         hl.value.yield %18 : !hl.int
 // CHECK:       }
 // CHECK:       %16 = macroni.parameter "Y" : !hl.int {
 // CHECK:         %18 = macroni.expansion "MUL(A, B)" : !hl.int {
 // CHECK:           %19 = macroni.parameter "A" : !hl.int {
-// CHECK:             %22 = hl.const #hl.integer<2> : !hl.int
+// CHECK:             %22 = hl.const #core.integer<2> : !hl.int
 // CHECK:             hl.value.yield %22 : !hl.int
 // CHECK:           }
 // CHECK:           %20 = macroni.parameter "B" : !hl.int {
-// CHECK:             %22 = hl.const #hl.integer<3> : !hl.int
+// CHECK:             %22 = hl.const #core.integer<3> : !hl.int
 // CHECK:             hl.value.yield %22 : !hl.int
 // CHECK:           }
 // CHECK:           %21 = hl.mul %19, %20 : (!hl.int, !hl.int) -> !hl.int
@@ -165,7 +165,7 @@
 // CHECK:     %14 = macroni.expansion "ADD(X, Y)" : !hl.int {
 // CHECK:       %15 = macroni.parameter "X" : !hl.int {
 // CHECK:         %18 = macroni.expansion "ONE" : !hl.int {
-// CHECK:           %19 = hl.const #hl.integer<1> : !hl.int
+// CHECK:           %19 = hl.const #core.integer<1> : !hl.int
 // CHECK:           hl.value.yield %19 : !hl.int
 // CHECK:         }
 // CHECK:         hl.value.yield %18 : !hl.int
@@ -173,11 +173,11 @@
 // CHECK:       %16 = macroni.parameter "Y" : !hl.int {
 // CHECK:         %18 = macroni.expansion "MUL(A, B)" : !hl.int {
 // CHECK:           %19 = macroni.parameter "A" : !hl.int {
-// CHECK:             %22 = hl.const #hl.integer<2> : !hl.int
+// CHECK:             %22 = hl.const #core.integer<2> : !hl.int
 // CHECK:             hl.value.yield %22 : !hl.int
 // CHECK:           }
 // CHECK:           %20 = macroni.parameter "B" : !hl.int {
-// CHECK:             %22 = hl.const #hl.integer<3> : !hl.int
+// CHECK:             %22 = hl.const #core.integer<3> : !hl.int
 // CHECK:             hl.value.yield %22 : !hl.int
 // CHECK:           }
 // CHECK:           %21 = hl.mul %19, %20 : (!hl.int, !hl.int) -> !hl.int
@@ -194,7 +194,7 @@
 // CHECK:     %14 = macroni.expansion "ADD(X, Y)" : !hl.int {
 // CHECK:       %15 = macroni.parameter "X" : !hl.int {
 // CHECK:         %18 = macroni.expansion "ONE" : !hl.int {
-// CHECK:           %19 = hl.const #hl.integer<1> : !hl.int
+// CHECK:           %19 = hl.const #core.integer<1> : !hl.int
 // CHECK:           hl.value.yield %19 : !hl.int
 // CHECK:         }
 // CHECK:         hl.value.yield %18 : !hl.int
@@ -203,14 +203,14 @@
 // CHECK:         %18 = macroni.expansion "MUL(A, B)" : !hl.int {
 // CHECK:           %19 = macroni.parameter "A" : !hl.int {
 // CHECK:             %22 = macroni.expansion "ONE" : !hl.int {
-// CHECK:               %23 = hl.const #hl.integer<1> : !hl.int
+// CHECK:               %23 = hl.const #core.integer<1> : !hl.int
 // CHECK:               hl.value.yield %23 : !hl.int
 // CHECK:             }
 // CHECK:             hl.value.yield %22 : !hl.int
 // CHECK:           }
 // CHECK:           %20 = macroni.parameter "B" : !hl.int {
 // CHECK:             %22 = macroni.expansion "ONE" : !hl.int {
-// CHECK:               %23 = hl.const #hl.integer<1> : !hl.int
+// CHECK:               %23 = hl.const #core.integer<1> : !hl.int
 // CHECK:               hl.value.yield %23 : !hl.int
 // CHECK:             }
 // CHECK:             hl.value.yield %22 : !hl.int
@@ -230,11 +230,11 @@
 // CHECK:       %15 = macroni.parameter "X" : !hl.int {
 // CHECK:         %18 = macroni.expansion "MUL(A, B)" : !hl.int {
 // CHECK:           %19 = macroni.parameter "A" : !hl.int {
-// CHECK:             %22 = hl.const #hl.integer<1> : !hl.int
+// CHECK:             %22 = hl.const #core.integer<1> : !hl.int
 // CHECK:             hl.value.yield %22 : !hl.int
 // CHECK:           }
 // CHECK:           %20 = macroni.parameter "B" : !hl.int {
-// CHECK:             %22 = hl.const #hl.integer<2> : !hl.int
+// CHECK:             %22 = hl.const #core.integer<2> : !hl.int
 // CHECK:             hl.value.yield %22 : !hl.int
 // CHECK:           }
 // CHECK:           %21 = hl.mul %19, %20 : (!hl.int, !hl.int) -> !hl.int
@@ -243,7 +243,7 @@
 // CHECK:         hl.value.yield %18 : !hl.int
 // CHECK:       }
 // CHECK:       %16 = macroni.parameter "Y" : !hl.int {
-// CHECK:         %18 = hl.const #hl.integer<3> : !hl.int
+// CHECK:         %18 = hl.const #core.integer<3> : !hl.int
 // CHECK:         hl.value.yield %18 : !hl.int
 // CHECK:       }
 // CHECK:       %17 = hl.add %15, %16 : (!hl.int, !hl.int) -> !hl.int
@@ -256,11 +256,11 @@
 // CHECK:       %15 = macroni.parameter "X" : !hl.int {
 // CHECK:         %18 = macroni.expansion "MUL(A, B)" : !hl.int {
 // CHECK:           %19 = macroni.parameter "A" : !hl.int {
-// CHECK:             %22 = hl.const #hl.integer<1> : !hl.int
+// CHECK:             %22 = hl.const #core.integer<1> : !hl.int
 // CHECK:             hl.value.yield %22 : !hl.int
 // CHECK:           }
 // CHECK:           %20 = macroni.parameter "B" : !hl.int {
-// CHECK:             %22 = hl.const #hl.integer<2> : !hl.int
+// CHECK:             %22 = hl.const #core.integer<2> : !hl.int
 // CHECK:             hl.value.yield %22 : !hl.int
 // CHECK:           }
 // CHECK:           %21 = hl.mul %19, %20 : (!hl.int, !hl.int) -> !hl.int
@@ -270,7 +270,7 @@
 // CHECK:       }
 // CHECK:       %16 = macroni.parameter "Y" : !hl.int {
 // CHECK:         %18 = macroni.expansion "ONE" : !hl.int {
-// CHECK:           %19 = hl.const #hl.integer<1> : !hl.int
+// CHECK:           %19 = hl.const #core.integer<1> : !hl.int
 // CHECK:           hl.value.yield %19 : !hl.int
 // CHECK:         }
 // CHECK:         hl.value.yield %18 : !hl.int
@@ -285,11 +285,11 @@
 // CHECK:       %15 = macroni.parameter "X" : !hl.int {
 // CHECK:         %18 = macroni.expansion "MUL(A, B)" : !hl.int {
 // CHECK:           %19 = macroni.parameter "A" : !hl.int {
-// CHECK:             %22 = hl.const #hl.integer<1> : !hl.int
+// CHECK:             %22 = hl.const #core.integer<1> : !hl.int
 // CHECK:             hl.value.yield %22 : !hl.int
 // CHECK:           }
 // CHECK:           %20 = macroni.parameter "B" : !hl.int {
-// CHECK:             %22 = hl.const #hl.integer<2> : !hl.int
+// CHECK:             %22 = hl.const #core.integer<2> : !hl.int
 // CHECK:             hl.value.yield %22 : !hl.int
 // CHECK:           }
 // CHECK:           %21 = hl.mul %19, %20 : (!hl.int, !hl.int) -> !hl.int
@@ -301,14 +301,14 @@
 // CHECK:         %18 = macroni.expansion "MUL(A, B)" : !hl.int {
 // CHECK:           %19 = macroni.parameter "A" : !hl.int {
 // CHECK:             %22 = macroni.expansion "ONE" : !hl.int {
-// CHECK:               %23 = hl.const #hl.integer<1> : !hl.int
+// CHECK:               %23 = hl.const #core.integer<1> : !hl.int
 // CHECK:               hl.value.yield %23 : !hl.int
 // CHECK:             }
 // CHECK:             hl.value.yield %22 : !hl.int
 // CHECK:           }
 // CHECK:           %20 = macroni.parameter "B" : !hl.int {
 // CHECK:             %22 = macroni.expansion "ONE" : !hl.int {
-// CHECK:               %23 = hl.const #hl.integer<1> : !hl.int
+// CHECK:               %23 = hl.const #core.integer<1> : !hl.int
 // CHECK:               hl.value.yield %23 : !hl.int
 // CHECK:             }
 // CHECK:             hl.value.yield %22 : !hl.int
@@ -329,14 +329,14 @@
 // CHECK:         %18 = macroni.expansion "MUL(A, B)" : !hl.int {
 // CHECK:           %19 = macroni.parameter "A" : !hl.int {
 // CHECK:             %22 = macroni.expansion "ONE" : !hl.int {
-// CHECK:               %23 = hl.const #hl.integer<1> : !hl.int
+// CHECK:               %23 = hl.const #core.integer<1> : !hl.int
 // CHECK:               hl.value.yield %23 : !hl.int
 // CHECK:             }
 // CHECK:             hl.value.yield %22 : !hl.int
 // CHECK:           }
 // CHECK:           %20 = macroni.parameter "B" : !hl.int {
 // CHECK:             %22 = macroni.expansion "ONE" : !hl.int {
-// CHECK:               %23 = hl.const #hl.integer<1> : !hl.int
+// CHECK:               %23 = hl.const #core.integer<1> : !hl.int
 // CHECK:               hl.value.yield %23 : !hl.int
 // CHECK:             }
 // CHECK:             hl.value.yield %22 : !hl.int
@@ -350,14 +350,14 @@
 // CHECK:         %18 = macroni.expansion "MUL(A, B)" : !hl.int {
 // CHECK:           %19 = macroni.parameter "A" : !hl.int {
 // CHECK:             %22 = macroni.expansion "ONE" : !hl.int {
-// CHECK:               %23 = hl.const #hl.integer<1> : !hl.int
+// CHECK:               %23 = hl.const #core.integer<1> : !hl.int
 // CHECK:               hl.value.yield %23 : !hl.int
 // CHECK:             }
 // CHECK:             hl.value.yield %22 : !hl.int
 // CHECK:           }
 // CHECK:           %20 = macroni.parameter "B" : !hl.int {
 // CHECK:             %22 = macroni.expansion "ONE" : !hl.int {
-// CHECK:               %23 = hl.const #hl.integer<1> : !hl.int
+// CHECK:               %23 = hl.const #core.integer<1> : !hl.int
 // CHECK:               hl.value.yield %23 : !hl.int
 // CHECK:             }
 // CHECK:             hl.value.yield %22 : !hl.int
@@ -372,89 +372,89 @@
 // CHECK:     }
 // CHECK:     hl.value.yield %14 : !hl.int
 // CHECK:   }
-// CHECK:   hl.func external @main (%arg0: !hl.lvalue<!hl.int>, %arg1: !hl.lvalue<!hl.decayed<!hl.ptr<!hl.ptr<!hl.char< const >>>>>) -> !hl.int {
-// CHECK:     hl.scope {
+// CHECK:   hl.func @main (%arg0: !hl.lvalue<!hl.int>, %arg1: !hl.lvalue<!hl.decayed<!hl.ptr<!hl.ptr<!hl.char< const >>>>>) -> !hl.int {
+// CHECK:     core.scope {
 // CHECK:       %14 = hl.var "x" : !hl.lvalue<!hl.int>
 // CHECK:       macroni.expansion "DO_NO_TRAILING_SEMI(STMT)" :  {
 // CHECK:         hl.do {
-// CHECK:           hl.scope {
+// CHECK:           core.scope {
 // CHECK:             %16 = macroni.parameter "STMT" : !hl.int {
 // CHECK:               %17 = hl.ref %14 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
-// CHECK:               %18 = hl.const #hl.integer<0> : !hl.int
+// CHECK:               %18 = hl.const #core.integer<0> : !hl.int
 // CHECK:               %19 = hl.assign %18 to %17 : !hl.int, !hl.lvalue<!hl.int> -> !hl.int
 // CHECK:               hl.value.yield %19 : !hl.int
 // CHECK:             }
 // CHECK:           }
 // CHECK:         } while {
-// CHECK:           %16 = hl.const #hl.integer<0> : !hl.int
+// CHECK:           %16 = hl.const #core.integer<0> : !hl.int
 // CHECK:           hl.cond.yield %16 : !hl.int
 // CHECK:         }
 // CHECK:       }
 // CHECK:       macroni.expansion "DO_NO_TRAILING_SEMI(STMT)" :  {
 // CHECK:         hl.do {
-// CHECK:           hl.scope {
+// CHECK:           core.scope {
 // CHECK:             macroni.parameter "STMT" :  {
 // CHECK:               macroni.expansion "DO_NO_TRAILING_SEMI(STMT)" :  {
 // CHECK:                 hl.do {
-// CHECK:                   hl.scope {
+// CHECK:                   core.scope {
 // CHECK:                     %16 = macroni.parameter "STMT" : !hl.int {
 // CHECK:                       %17 = hl.ref %14 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
-// CHECK:                       %18 = hl.const #hl.integer<0> : !hl.int
+// CHECK:                       %18 = hl.const #core.integer<0> : !hl.int
 // CHECK:                       %19 = hl.assign %18 to %17 : !hl.int, !hl.lvalue<!hl.int> -> !hl.int
 // CHECK:                       hl.value.yield %19 : !hl.int
 // CHECK:                     }
 // CHECK:                   }
 // CHECK:                 } while {
-// CHECK:                   %16 = hl.const #hl.integer<0> : !hl.int
+// CHECK:                   %16 = hl.const #core.integer<0> : !hl.int
 // CHECK:                   hl.cond.yield %16 : !hl.int
 // CHECK:                 }
 // CHECK:               }
 // CHECK:             }
 // CHECK:           }
 // CHECK:         } while {
-// CHECK:           %16 = hl.const #hl.integer<0> : !hl.int
+// CHECK:           %16 = hl.const #core.integer<0> : !hl.int
 // CHECK:           hl.cond.yield %16 : !hl.int
 // CHECK:         }
 // CHECK:       }
 // CHECK:       macroni.expansion "DO_TRAILING_SEMI(STMT)" :  {
 // CHECK:         hl.do {
-// CHECK:           hl.scope {
+// CHECK:           core.scope {
 // CHECK:             %16 = macroni.parameter "STMT" : !hl.int {
 // CHECK:               %17 = hl.ref %14 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
-// CHECK:               %18 = hl.const #hl.integer<1> : !hl.int
+// CHECK:               %18 = hl.const #core.integer<1> : !hl.int
 // CHECK:               %19 = hl.assign %18 to %17 : !hl.int, !hl.lvalue<!hl.int> -> !hl.int
 // CHECK:               hl.value.yield %19 : !hl.int
 // CHECK:             }
 // CHECK:           }
 // CHECK:         } while {
-// CHECK:           %16 = hl.const #hl.integer<0> : !hl.int
+// CHECK:           %16 = hl.const #core.integer<0> : !hl.int
 // CHECK:           hl.cond.yield %16 : !hl.int
 // CHECK:         }
 // CHECK:       }
 // CHECK:       macroni.expansion "DO_TRAILING_SEMI(STMT)" :  {
 // CHECK:         hl.do {
-// CHECK:           hl.scope {
+// CHECK:           core.scope {
 // CHECK:             hl.do {
-// CHECK:               hl.scope {
+// CHECK:               core.scope {
 // CHECK:                 %16 = macroni.parameter "STMT" : !hl.int {
 // CHECK:                   %17 = hl.ref %14 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
-// CHECK:                   %18 = hl.const #hl.integer<1> : !hl.int
+// CHECK:                   %18 = hl.const #core.integer<1> : !hl.int
 // CHECK:                   %19 = hl.assign %18 to %17 : !hl.int, !hl.lvalue<!hl.int> -> !hl.int
 // CHECK:                   hl.value.yield %19 : !hl.int
 // CHECK:                 }
 // CHECK:               }
 // CHECK:             } while {
-// CHECK:               %16 = hl.const #hl.integer<0> : !hl.int
+// CHECK:               %16 = hl.const #core.integer<0> : !hl.int
 // CHECK:               hl.cond.yield %16 : !hl.int
 // CHECK:             }
 // CHECK:             hl.skip
 // CHECK:           }
 // CHECK:         } while {
-// CHECK:           %16 = hl.const #hl.integer<0> : !hl.int
+// CHECK:           %16 = hl.const #core.integer<0> : !hl.int
 // CHECK:           hl.cond.yield %16 : !hl.int
 // CHECK:         }
 // CHECK:       }
-// CHECK:       %15 = hl.const #hl.integer<0> : !hl.int
+// CHECK:       %15 = hl.const #core.integer<0> : !hl.int
 // CHECK:       hl.return %15 : !hl.int
 // CHECK:     }
 // CHECK:   }

--- a/test/SafetyTests/unsafe.c
+++ b/test/SafetyTests/unsafe.c
@@ -18,12 +18,12 @@
 // CHECK:     hl.field "reg_save_area" : !hl.ptr<!hl.void>
 // CHECK:   }
 // CHECK:   hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
-// CHECK:   hl.func external @main () -> !hl.int {
-// CHECK:     hl.scope {
+// CHECK:   hl.func @main () -> !hl.int {
+// CHECK:     core.scope {
 // CHECK:       "safety.unsafe"() ({
 // CHECK:         hl.skip
 // CHECK:       }) : () -> ()
-// CHECK:       %0 = hl.const #hl.integer<0> : !hl.int
+// CHECK:       %0 = hl.const #core.integer<0> : !hl.int
 // CHECK:       hl.return %0 : !hl.int
 // CHECK:     }
 // CHECK:   }

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -52,17 +52,17 @@ tools = [
     ToolSubst(
         "kernelize",
         os.path.join(config.macroni_obj_root, 'bin',
-                     'Kernelize', 'RelWithDebInfo', 'kernelize')),
+                     'Kernelize', 'Debug', 'kernelize')),
 
     ToolSubst(
         "macronify",
         os.path.join(config.macroni_obj_root, 'bin',
-                     'Macronify', 'RelWithDebInfo', 'macronify')),
+                     'Macronify', 'Debug', 'macronify')),
 
     ToolSubst(
         "safe-c",
         os.path.join(config.macroni_obj_root, 'bin',
-                     'SafeC', 'RelWithDebInfo', 'safe-c')),
+                     'SafeC', 'Debug', 'safe-c')),
 
     ToolSubst(
         "FileCheck",


### PR DESCRIPTION
- Use `Debug` build for binaries instead of `RelWithDebugInfo`
- Update expected output for test cases to match VAST updates