### PR TITLE
Add kernel warnings for calls to `rcu_dereference()` macros outside of RCU critical sections

### DIFF
--- a/bin/Kernelize/KernelCodeGenVisitorMixin.hpp
+++ b/bin/Kernelize/KernelCodeGenVisitorMixin.hpp
@@ -36,9 +36,9 @@ struct KernelCodeGenVisitorMixin
         anno && is_context_attr(anno)) {
       const auto *context_arg_1 = *anno->args_begin();
       const auto *context_arg_2 = clang::dyn_cast_or_null<clang::ConstantExpr>(
-          *(anno->args_begin() + 1));
+          *std::next(anno->args_begin(), 1));
       const auto *context_arg_3 = clang::dyn_cast_or_null<clang::ConstantExpr>(
-          *(anno->args_begin() + 2));
+          *std::next(anno->args_begin(), 2));
       if (!(context_arg_1 && context_arg_2 && context_arg_3)) {
         return parent_t::attr_visitor::Visit(attr);
       }

--- a/bin/Kernelize/KernelCodeGenVisitorMixin.hpp
+++ b/bin/Kernelize/KernelCodeGenVisitorMixin.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <macroni/Dialect/Kernel/KernelAttributes.hpp>
 #include <macroni/Dialect/Kernel/KernelDialect.hpp>
 #include <macroni/Dialect/Kernel/KernelTypes.hpp>
 #include <macroni/Translation/MacroniCodeGenVisitorMixin.hpp>
@@ -18,14 +19,49 @@ struct KernelCodeGenVisitorMixin
   using parent_t = macroni::MacroniCodeGenVisitorMixin<Derived>;
 
   using parent_t::mlir_builder;
+  using parent_t::stmt_visitor::lens::acontext;
   using parent_t::stmt_visitor::lens::mcontext;
 
   using parent_t::Visit;
 
   std::int64_t lock_level = 0;
 
+  bool is_context_attr(const clang::AnnotateAttr *attr) {
+    return attr->getAttrName()->getName() == "context" &&
+           attr->args_size() == 3;
+  }
+
+  mlir::Attribute Visit(const clang::Attr *attr) {
+    if (const auto *anno = clang::dyn_cast<clang::AnnotateAttr>(attr);
+        anno && is_context_attr(anno)) {
+      const auto *context_arg_1 = *anno->args_begin();
+      const auto *context_arg_2 = clang::dyn_cast_or_null<clang::ConstantExpr>(
+          *(anno->args_begin() + 1));
+      const auto *context_arg_3 = clang::dyn_cast_or_null<clang::ConstantExpr>(
+          *(anno->args_begin() + 2));
+      if (!(context_arg_1 && context_arg_2 && context_arg_3)) {
+        return parent_t::attr_visitor::Visit(attr);
+      }
+      std::string lock;
+      auto os = llvm::raw_string_ostream(lock);
+      context_arg_1->printPretty(os, nullptr, acontext().getPrintingPolicy());
+      auto lock_name = mlir::StringAttr::get(&mcontext(), llvm::Twine(lock));
+
+      auto starts_with_lock = context_arg_2->getResultAsAPSInt();
+      auto ends_with_lock = context_arg_3->getResultAsAPSInt();
+      if (starts_with_lock == 1 && ends_with_lock == 1) {
+        return macroni::kernel::MustHoldAttr::get(&mcontext(), lock_name);
+      } else if (starts_with_lock == 0 && ends_with_lock == 1) {
+        return macroni::kernel::AcquiresAttr::get(&mcontext(), lock_name);
+      } else if (starts_with_lock == 1 && ends_with_lock == 0) {
+        return macroni::kernel::ReleasesAttr::get(&mcontext(), lock_name);
+      }
+    }
+    return parent_t::attr_visitor::Visit(attr);
+  }
+
   mlir::Type Visit(clang::QualType type) {
-    auto ty = parent_t::type_visitor_with_dl::Visit(type);
+    auto ty = parent_t::type_visitor::Visit(type);
     auto attributed_type = clang::dyn_cast<clang::AttributedType>(type);
     if (!attributed_type) {
       return ty;

--- a/bin/Kernelize/KernelCodeGenVisitorMixin.hpp
+++ b/bin/Kernelize/KernelCodeGenVisitorMixin.hpp
@@ -67,7 +67,7 @@ struct KernelCodeGenVisitorMixin
   }
 
   void VisitCallExpr(pasta::CallExpr &call_expr, mlir::Operation *op) {
-    auto call_op = mlir::dyn_cast<vast::hl::CallOp>(op);
+    auto call_op = mlir::dyn_cast_or_null<vast::hl::CallOp>(op);
     if (!call_op) {
       return;
     }

--- a/bin/Kernelize/Main.cpp
+++ b/bin/Kernelize/Main.cpp
@@ -44,6 +44,8 @@ int main(int argc, char **argv) {
       .add(macroni::kernel::rewrite_rcu_dereference)
       .add(macroni::kernel::rewrite_rcu_dereference_check)
       .add(macroni::kernel::rewrite_rcu_access_pointer)
+      .add(macroni::kernel::rewrite_rcu_assign_pointer)
+      .add(macroni::kernel::rewrite_rcu_replace_pointer)
       .add(macroni::kernel::rewrite_smp_mb)
       .add(macroni::kernel::rewrite_list_for_each)
       .add(macroni::kernel::rewrite_label_stmt)
@@ -84,7 +86,9 @@ int main(int argc, char **argv) {
                   macroni::kernel::RCUDereferenceBHCheck,
                   macroni::kernel::RCUDereferenceSchedCheck,
                   macroni::kernel::RCUDereferenceProtected,
-                  macroni::kernel::RCUAccessPointer>(op)) {
+                  macroni::kernel::RCUAccessPointer,
+                  macroni::kernel::RCUAssignPointer,
+                  macroni::kernel::RCUReplacePointer>(op)) {
       std::string s;
       auto os = llvm::raw_string_ostream(s);
       op->getLoc()->print(os);

--- a/bin/Kernelize/Main.cpp
+++ b/bin/Kernelize/Main.cpp
@@ -19,7 +19,6 @@
 #include <mlir/Pass/PassManager.h>
 #include <mlir/Transforms/GreedyPatternRewriteDriver.h>
 #include <mlir/Transforms/Passes.h>
-#include <optional>
 #include <pasta/AST/AST.h>
 #include <string>
 #include <vast/CodeGen/CodeGen.hpp>

--- a/bin/Kernelize/Main.cpp
+++ b/bin/Kernelize/Main.cpp
@@ -103,8 +103,8 @@ void check_critical_section_section_for_rcu_invocations(
     macroni::kernel::RCUCriticalSection cs) {
   cs.walk([](macroni::kernel::RCUAccessPointer op) {
     op->emitWarning() << format_location(op)
-                      << ": suggestion: Use rcu_dereference_protected() "
-                         "instead of rcu_access_pointer()\n";
+                      << ": info: Use rcu_dereference_protected() instead of "
+                         "rcu_access_pointer()\n";
   });
 }
 

--- a/bin/Kernelize/Main.cpp
+++ b/bin/Kernelize/Main.cpp
@@ -9,6 +9,7 @@
 #include <macroni/Common/GenerateMacroniModule.hpp>
 #include <macroni/Common/ParseAST.hpp>
 #include <macroni/Conversion/Kernel/KernelRewriters.hpp>
+#include <mlir/IR/Diagnostics.h>
 #include <mlir/Pass/Pass.h>
 #include <mlir/Pass/PassManager.h>
 #include <mlir/Transforms/GreedyPatternRewriteDriver.h>
@@ -27,7 +28,8 @@ int main(int argc, char **argv) {
 
   // Register the MLIR dialects we will be lowering to
   mlir::DialectRegistry registry;
-  registry.insert<vast::hl::HighLevelDialect, macroni::macroni::MacroniDialect,
+  registry.insert<vast::hl::HighLevelDialect, vast::unsup::UnsupportedDialect,
+                  macroni::macroni::MacroniDialect,
                   macroni::kernel::KernelDialect>();
   auto mctx = mlir::MLIRContext(registry);
 
@@ -40,21 +42,77 @@ int main(int argc, char **argv) {
       .add(macroni::kernel::rewrite_offsetof)
       .add(macroni::kernel::rewrite_container_of)
       .add(macroni::kernel::rewrite_rcu_dereference)
+      .add(macroni::kernel::rewrite_rcu_dereference_check)
       .add(macroni::kernel::rewrite_smp_mb)
       .add(macroni::kernel::rewrite_list_for_each)
+      .add(macroni::kernel::rewrite_label_stmt)
       .add(macroni::kernel::rewrite_rcu_read_unlock);
 
   // Apply the conversions
   auto frozen_pats = mlir::FrozenRewritePatternSet(std::move(patterns));
   mod->walk([&frozen_pats](mlir::Operation *op) {
     if (mlir::isa<macroni::macroni::MacroExpansion, vast::hl::ForOp,
-                  vast::hl::CallOp>(op)) {
+                  vast::hl::CallOp, vast::hl::LabelStmt>(op)) {
       std::ignore = mlir::applyOpPatternsAndFold(op, frozen_pats);
     }
   });
 
   // Print the result
   mod->print(llvm::outs());
+
+  mlir::DiagnosticEngine &engine = mctx.getDiagEngine();
+  auto diagnostic_handler = engine.registerHandler([](mlir::Diagnostic &diag) {
+    diag.print(llvm::errs());
+    return;
+  });
+
+  mod->walk<mlir::WalkOrder::PreOrder>([](mlir::Operation *op) {
+    if (mlir::isa<macroni::kernel::RCUCriticalSection>(op)) {
+      // NOTE(bpp): Skip checking for invocations of RCU macros inside RCU
+      // critical sections because we only want to emit warnings for invocations
+      // of RCU macros outside of critical sections. We walk the tree using
+      // pre-order traversal instead of using post-order traversal (the default)
+      // in order for this to work.
+      return mlir::WalkResult::skip();
+    }
+    if (mlir::isa<macroni::kernel::RCUDereference,
+                  macroni::kernel::RCUDereferenceBH,
+                  macroni::kernel::RCUDereferenceSched,
+                  macroni::kernel::RCUDereferenceCheck,
+                  macroni::kernel::RCUDereferenceBHCheck,
+                  macroni::kernel::RCUDereferenceSchedCheck,
+                  macroni::kernel::RCUDereferenceProtected>(op)) {
+      auto name = "<error>";
+      if (mlir::isa<macroni::kernel::RCUDereference>(op)) {
+        name = "rcu_dereference";
+      } else if (mlir::isa<macroni::kernel::RCUDereferenceBH>(op)) {
+        name = "rcu_dereference_bh";
+      } else if (mlir::isa<macroni::kernel::RCUDereferenceSched>(op)) {
+        name = "rcu_dereference_sched";
+      } else if (mlir::isa<macroni::kernel::RCUDereferenceCheck>(op)) {
+        name = "rcu_dereference_check";
+      } else if (mlir::isa<macroni::kernel::RCUDereferenceBHCheck>(op)) {
+        name = "rcu_dereference_bh_check";
+      } else if (mlir::isa<macroni::kernel::RCUDereferenceSchedCheck>(op)) {
+        name = "rcu_dereference_sched_check";
+      } else if (mlir::isa<macroni::kernel::RCUDereferenceProtected>(op)) {
+        name = "rcu_dereference_protected";
+      }
+      std::string s;
+      auto os = llvm::raw_string_ostream(s);
+      op->getLoc()->print(os);
+      s.erase(s.find("loc("), 4);
+      s.erase(s.find('"'), 1);
+      s.erase(s.find('"'), 1);
+      s.erase(s.rfind(')'), 1);
+      os << ": warning: Invocation of " << name
+         << "() outside of RCU critical section\n";
+      op->emitWarning() << s;
+    }
+    return mlir::WalkResult::advance();
+  });
+
+  engine.eraseHandler(diagnostic_handler);
 
   return EXIT_SUCCESS;
 }

--- a/bin/Macronify/CMakeLists.txt
+++ b/bin/Macronify/CMakeLists.txt
@@ -10,6 +10,7 @@ target_link_libraries(macronify
         macroni_api
         MLIRMacroni
         VAST::VASTCodeGen
+        VAST::VASTFrontend
 )
 
 mlir_check_link_libraries(macronify)

--- a/include/macroni/Conversion/Kernel/KernelRewriters.hpp
+++ b/include/macroni/Conversion/Kernel/KernelRewriters.hpp
@@ -20,11 +20,15 @@ mlir::LogicalResult rewrite_container_of(macroni::MacroExpansion exp,
 mlir::LogicalResult rewrite_rcu_dereference(macroni::MacroExpansion exp,
                                             mlir::PatternRewriter &rewriter);
 
-mlir::LogicalResult rewrite_rcu_dereference_check(macroni::MacroExpansion exp,
-                                            mlir::PatternRewriter &rewriter);
+mlir::LogicalResult
+rewrite_rcu_dereference_check(macroni::MacroExpansion exp,
+                              mlir::PatternRewriter &rewriter);
 
 mlir::LogicalResult rewrite_smp_mb(macroni::MacroExpansion exp,
                                    mlir::PatternRewriter &rewriter);
+
+mlir::LogicalResult rewrite_rcu_access_pointer(macroni::MacroExpansion exp,
+                                               mlir::PatternRewriter &rewriter);
 
 mlir::LogicalResult rewrite_list_for_each(vast::hl::ForOp for_op,
                                           mlir::PatternRewriter &rewriter);

--- a/include/macroni/Conversion/Kernel/KernelRewriters.hpp
+++ b/include/macroni/Conversion/Kernel/KernelRewriters.hpp
@@ -30,6 +30,13 @@ mlir::LogicalResult rewrite_smp_mb(macroni::MacroExpansion exp,
 mlir::LogicalResult rewrite_rcu_access_pointer(macroni::MacroExpansion exp,
                                                mlir::PatternRewriter &rewriter);
 
+mlir::LogicalResult rewrite_rcu_assign_pointer(macroni::MacroExpansion exp,
+                                               mlir::PatternRewriter &rewriter);
+
+mlir::LogicalResult
+rewrite_rcu_replace_pointer(macroni::MacroExpansion exp,
+                            mlir::PatternRewriter &rewriter);
+
 mlir::LogicalResult rewrite_list_for_each(vast::hl::ForOp for_op,
                                           mlir::PatternRewriter &rewriter);
 

--- a/include/macroni/Conversion/Kernel/KernelRewriters.hpp
+++ b/include/macroni/Conversion/Kernel/KernelRewriters.hpp
@@ -20,6 +20,9 @@ mlir::LogicalResult rewrite_container_of(macroni::MacroExpansion exp,
 mlir::LogicalResult rewrite_rcu_dereference(macroni::MacroExpansion exp,
                                             mlir::PatternRewriter &rewriter);
 
+mlir::LogicalResult rewrite_rcu_dereference_check(macroni::MacroExpansion exp,
+                                            mlir::PatternRewriter &rewriter);
+
 mlir::LogicalResult rewrite_smp_mb(macroni::MacroExpansion exp,
                                    mlir::PatternRewriter &rewriter);
 
@@ -28,4 +31,7 @@ mlir::LogicalResult rewrite_list_for_each(vast::hl::ForOp for_op,
 
 mlir::LogicalResult rewrite_rcu_read_unlock(vast::hl::CallOp call_op,
                                             mlir::PatternRewriter &rewriter);
+
+mlir::LogicalResult rewrite_label_stmt(vast::hl::LabelStmt label_stmt,
+                                       mlir::PatternRewriter &rewriter);
 } // namespace macroni::kernel

--- a/include/macroni/Dialect/Kernel/CMakeLists.txt
+++ b/include/macroni/Dialect/Kernel/CMakeLists.txt
@@ -1,5 +1,15 @@
 # Copyright (c) 2023-present, Trail of Bits, Inc.
+
+set(LLVM_TARGET_DEFINITIONS Kernel.td)
 add_mlir_dialect(Kernel kernel)
 add_mlir_doc(Kernel Kernel Kernel/ -gen-dialect-doc)
 
-set(LLVM_TARGET_DEFINITIONS Kernel.td)
+set(LLVM_TARGET_DEFINITIONS KernelAttributes.td)
+mlir_tablegen(KernelAttributes.h.inc -gen-attrdef-decls)
+mlir_tablegen(KernelAttributes.cpp.inc -gen-attrdef-defs)
+add_public_tablegen_target(MLIRKernelAttributesIncGen)
+
+set(LLVM_TARGET_DEFINITIONS KernelInterfaces.td)
+mlir_tablegen(KernelInterfaces.h.inc -gen-op-interface-decls)
+mlir_tablegen(KernelInterfaces.cpp.inc -gen-op-interface-defs)
+add_public_tablegen_target(MLIRKernelInterfacesIncGen)

--- a/include/macroni/Dialect/Kernel/Kernel.td
+++ b/include/macroni/Dialect/Kernel/Kernel.td
@@ -25,17 +25,21 @@ def Kernel_Dialect : Dialect {
 
     let extraClassDeclaration = [{
         void registerTypes();
+        void registerAttributes();
         static llvm::StringRef rcu_read_lock() { return "rcu_read_lock"; }
         static llvm::StringRef rcu_read_unlock() { return "rcu_read_unlock"; }
     }];
 
     let useDefaultTypePrinterParser = 1;
+    let useDefaultAttributePrinterParser = 1;
 }
 
 class Kernel_Op<string mnemonic, list<Trait> traits = []>
     : Op<Kernel_Dialect, mnemonic, traits>;
 
-include "KernelOps.td"
+include "KernelAttributes.td"
 include "KernelTypes.td"
+include "KernelInterfaces.td"
+include "KernelOps.td"
 
 #endif // MACRONI_DIALECT_IR_KERNEL

--- a/include/macroni/Dialect/Kernel/KernelAttributes.hpp
+++ b/include/macroni/Dialect/Kernel/KernelAttributes.hpp
@@ -1,0 +1,8 @@
+// Copyright (c) 2023-present, Trail of Bits, Inc.
+
+#pragma once
+
+#include <macroni/Dialect/Kernel/KernelDialect.hpp>
+
+#define GET_ATTRDEF_CLASSES
+#include <macroni/Dialect/Kernel/KernelAttributes.h.inc>

--- a/include/macroni/Dialect/Kernel/KernelAttributes.td
+++ b/include/macroni/Dialect/Kernel/KernelAttributes.td
@@ -1,0 +1,31 @@
+#ifndef MACRONI_DIALECT_KERNEL_IR_KERNELATTRIBUTES
+#define MACRONI_DIALECT_KERNEL_IR_KERNELATTRIBUTES
+
+include "mlir/IR/OpBase.td"
+include "mlir/IR/EnumAttr.td"
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/BuiltinAttributeInterfaces.td"
+
+include "macroni/Dialect/Kernel/Kernel.td"
+
+//
+// Generic kernel attribute
+//
+class KernelAttr<string name, string attr_mnemonic, list<Trait> traits = []>
+    : AttrDef<Kernel_Dialect, name, traits>
+{
+  let mnemonic = attr_mnemonic;
+}
+
+class ContextAttr<string name, string attr_mnemonic>
+  : KernelAttr< name, attr_mnemonic >
+{
+  let parameters = (ins "::mlir::StringAttr":$lock);
+  let assemblyFormat = "`<` $lock `>`";
+}
+
+def MustHoldAttr : ContextAttr < "MustHold", "__must_hold" >;
+def AcquiresAttr : ContextAttr < "Acquires", "__acquires" >;
+def ReleasesAttr : ContextAttr < "Releases", "__releases" >;
+
+#endif // MACRONI_DIALECT_KERNEL_IR_KERNELATTRIBUTES

--- a/include/macroni/Dialect/Kernel/KernelInterfaces.hpp
+++ b/include/macroni/Dialect/Kernel/KernelInterfaces.hpp
@@ -1,0 +1,16 @@
+// Copyright (c) 2024-present, Trail of Bits, Inc.
+
+#pragma once
+
+#include <vast/Util/Warnings.hpp>
+
+VAST_RELAX_WARNINGS
+#include <mlir/IR/BuiltinOps.h>
+#include <mlir/IR/BuiltinTypes.h>
+#include <mlir/IR/Dialect.h>
+#include <mlir/IR/OperationSupport.h>
+VAST_RELAX_WARNINGS
+
+
+/// Include the generated interface declarations.
+#include <macroni/Dialect/Kernel/KernelInterfaces.h.inc>

--- a/include/macroni/Dialect/Kernel/KernelInterfaces.td
+++ b/include/macroni/Dialect/Kernel/KernelInterfaces.td
@@ -8,4 +8,9 @@ def RCU_Macro_Interface :
   let cppNamespace = "::macroni::kernel";
 }
 
+def RCU_Dereference_Interface :
+  OpInterface<"RCU_Dereference_Interface"> {
+  let cppNamespace = "::macroni::kernel";
+}
+
 #endif // KERNEL_IR_KERNEL_INTERFACES

--- a/include/macroni/Dialect/Kernel/KernelInterfaces.td
+++ b/include/macroni/Dialect/Kernel/KernelInterfaces.td
@@ -1,0 +1,11 @@
+#ifndef KERNEL_IR_KERNEL_INTERFACES
+#define KERNEL_IR_KERNEL_INTERFACES
+
+include "mlir/IR/OpBase.td"
+
+def RCU_Macro_Interface :
+  OpInterface<"RCU_Macro_Interface"> {
+  let cppNamespace = "::macroni::kernel";
+}
+
+#endif // KERNEL_IR_KERNEL_INTERFACES

--- a/include/macroni/Dialect/Kernel/KernelOps.hpp
+++ b/include/macroni/Dialect/Kernel/KernelOps.hpp
@@ -13,5 +13,8 @@ VAST_RELAX_WARNINGS
 #include <mlir/Support/TypeID.h>
 VAST_UNRELAX_WARNINGS
 
+#include <macroni/Dialect/Kernel/KernelAttributes.hpp>
+#include <macroni/Dialect/Kernel/KernelTypes.hpp>
+
 #define GET_OP_CLASSES
 #include "macroni/Dialect/Kernel/Kernel.h.inc"

--- a/include/macroni/Dialect/Kernel/KernelOps.td
+++ b/include/macroni/Dialect/Kernel/KernelOps.td
@@ -119,10 +119,126 @@ def RCUDereference :
   let description = [{
     rcu_dereference() - fetch RCU-protected pointer for dereferencing
     @p: The pointer to read, prior to dereferencing
-    This is a simple wrapper around rcu_dereference_check().
+    See https://www.kernel.org/doc/html/next/core-api/kernel-api.html
   }];
   let assemblyFormat = [{
     `rcu_dereference` `(` $p `)` attr-dict
+    `:` functional-type( operands, results )
+  }];
+}
+
+def RCUDereferenceBH :
+  Kernel_Op< "rcu_dereference_bh", [] >
+  , Arguments<(ins AnyType:$p)>
+  , Results<(outs AnyType:$result)> {
+  let summary = "An expansion of the Linux kernel macro, rcu_dereference_bh()";
+  let description = [{
+    rcu_dereference_bh() - fetch an RCU-bh-protected pointer for dereferencing
+    @p: The pointer to read, prior to dereferencing
+    See https://www.kernel.org/doc/html/next/core-api/kernel-api.html
+  }];
+  let assemblyFormat = [{
+    `rcu_dereference_bh` `(` $p `)` attr-dict
+    `:` functional-type( operands, results )
+  }];
+}
+
+def RCUDereferenceSched :
+  Kernel_Op< "rcu_dereference_sched", [] >
+  , Arguments<(ins AnyType:$p)>
+  , Results<(outs AnyType:$result)> {
+  let summary = "An expansion of the Linux kernel macro, rcu_dereference_sched()";
+  let description = [{
+    rcu_dereference_sched() - fetch RCU-sched-protected pointer for dereferencing
+    @p: The pointer to read, prior to dereferencing
+    See https://www.kernel.org/doc/html/next/core-api/kernel-api.html
+  }];
+  let assemblyFormat = [{
+    `rcu_dereference_sched` `(` $p `)` attr-dict
+    `:` functional-type( operands, results )
+  }];
+}
+
+def RCUDereferenceCheck :
+  Kernel_Op< "rcu_dereference_check", [] >
+  , Arguments<(ins
+    AnyType:$p,
+    AnyType:$c)>
+  , Results<(outs AnyType:$result)> {
+  let summary = [{
+    An expansion of the Linux kernel macro, rcu_dereference_check()
+  }];
+  let description = [{
+    rcu_dereference_check() - rcu_dereference with debug checking
+    @p: The pointer to read, prior to dereferencing
+    @c: The conditions under which the dereference will take place
+    See https://www.kernel.org/doc/html/next/core-api/kernel-api.html
+  }];
+  let assemblyFormat = [{
+    `rcu_dereference_check` `(` $p `,` $c `)` attr-dict
+    `:` functional-type( operands, results )
+  }];
+}
+
+def RCUDereferenceBHCheck :
+  Kernel_Op< "rcu_dereference_bh_check", [] >
+  , Arguments<(ins
+    AnyType:$p,
+    AnyType:$c)>
+  , Results<(outs AnyType:$result)> {
+  let summary = [{
+    An expansion of the Linux kernel macro, rcu_dereference_bh_check()
+  }];
+  let description = [{
+    rcu_dereference_bh_check() - rcu_dereference_bh with debug checking
+    @p: The pointer to read, prior to dereferencing
+    @c: The conditions under which the dereference will take place
+    See https://www.kernel.org/doc/html/next/core-api/kernel-api.html
+  }];
+  let assemblyFormat = [{
+    `rcu_dereference_bh_check` `(` $p `,` $c `)` attr-dict
+    `:` functional-type( operands, results )
+  }];
+}
+
+def RCUDereferenceSchedCheck :
+  Kernel_Op< "rcu_dereference_sched_check", [] >
+  , Arguments<(ins
+    AnyType:$p,
+    AnyType:$c)>
+  , Results<(outs AnyType:$result)> {
+  let summary = [{
+    An expansion of the Linux kernel macro, rcu_dereference_sched_check()
+  }];
+  let description = [{
+    rcu_dereference_sched_check() - rcu_dereference_sched with debug checking
+    @p: The pointer to read, prior to dereferencing
+    @c: The conditions under which the dereference will take place
+    See https://www.kernel.org/doc/html/next/core-api/kernel-api.html
+  }];
+  let assemblyFormat = [{
+    `rcu_dereference_sched_check` `(` $p `,` $c `)` attr-dict
+    `:` functional-type( operands, results )
+  }];
+}
+
+def RCUDereferenceProtected :
+  Kernel_Op< "rcu_dereference_protected", [] >
+  , Arguments<(ins
+    AnyType:$p,
+    AnyType:$c)>
+  , Results<(outs AnyType:$result)> {
+  let summary = [{
+    An expansion of the Linux kernel macro, rcu_dereference_protected()
+  }];
+  let description = [{
+    rcu_dereference_protected() - fetch RCU pointer when updates prevented
+    @p: The pointer to read, prior to dereferencing
+    @c: The conditions under which the dereference will take place
+    See https://www.kernel.org/doc/html/next/core-api/kernel-api.html
+  }];
+  let assemblyFormat = [{
+    `rcu_dereference_protected` `(` $p `,` $c `)` attr-dict
     `:` functional-type( operands, results )
   }];
 }

--- a/include/macroni/Dialect/Kernel/KernelOps.td
+++ b/include/macroni/Dialect/Kernel/KernelOps.td
@@ -243,6 +243,24 @@ def RCUDereferenceProtected :
   }];
 }
 
+def RCUAccessPointer :
+  Kernel_Op< "rcu_access_pointer", [] >
+  , Arguments<(ins AnyType:$p)>
+  , Results<(outs AnyType:$result)> {
+  let summary = [{
+    An expansion of the Linux kernel macro, rcu_access_pointer()
+  }];
+  let description = [{
+    rcu_access_pointer() - fetch RCU pointer with no dereferencing 
+    @p: The pointer to read
+    See https://www.kernel.org/doc/html/next/core-api/kernel-api.html
+  }];
+  let assemblyFormat = [{
+    `rcu_access_pointer` `(` $p `)` attr-dict
+    `:` functional-type( operands, results )
+  }];
+}
+
 def SMPMB :
   Kernel_Op< "smp_mb", [] >
   , Results<(outs AnyType:$result)> {

--- a/include/macroni/Dialect/Kernel/KernelOps.td
+++ b/include/macroni/Dialect/Kernel/KernelOps.td
@@ -261,6 +261,50 @@ def RCUAccessPointer :
   }];
 }
 
+def RCUAssignPointer :
+  Kernel_Op< "rcu_assign_pointer", [] >
+  , Arguments<(ins
+    AnyType:$p
+    , AnyType:$v)>
+  , Results<(outs AnyType:$result)> {
+  let summary = [{
+    An expansion of the Linux kernel macro, rcu_assign_pointer()
+  }];
+  let description = [{
+    rcu_assign_pointer() - assign to RCU-protected pointer
+    @p: The pointer to read
+    @v: The value to statically initialize with.
+    See https://www.kernel.org/doc/html/next/core-api/kernel-api.html
+  }];
+  let assemblyFormat = [{
+    `rcu_assign_pointer` `(` $p `,` $v `)` attr-dict
+    `:` functional-type( operands, results )
+  }];
+}
+
+def RCUReplacePointer :
+  Kernel_Op< "rcu_replace_pointer", [] >
+  , Arguments<(ins
+    AnyType:$rcu_ptr
+    , AnyType:$ptr
+    , AnyType:$c)>
+  , Results<(outs AnyType:$result)> {
+  let summary = [{
+    An expansion of the Linux kernel macro, rcu_replace_pointer()
+  }];
+  let description = [{
+    rcu_replace_pointer() - replace an RCU pointer, returning its old value
+    @rcu_ptr: RCU pointer, whose old value is returned
+    @ptr: regular pointer
+    @c: the lockdep conditions under which the dereference will take place
+    See https://www.kernel.org/doc/html/next/core-api/kernel-api.html
+  }];
+  let assemblyFormat = [{
+    `rcu_replace_pointer` `(` $rcu_ptr `,` $ptr `,` $c `)` attr-dict
+    `:` functional-type( operands, results )
+  }];
+}
+
 def SMPMB :
   Kernel_Op< "smp_mb", [] >
   , Results<(outs AnyType:$result)> {

--- a/include/macroni/Dialect/Kernel/KernelOps.td
+++ b/include/macroni/Dialect/Kernel/KernelOps.td
@@ -132,37 +132,39 @@ def RCUCriticalSection :
 /* RCU macros */
 
 class RCU_Op<string mnemonic, list<Trait> traits = []>
-  : Kernel_Op<mnemonic, traits>;
-
-class RCU_Deference_Op<
-  string mnemonic
-  , list<Trait>
-    traits = [DeclareOpInterfaceMethods<RCU_Macro_Interface>]
-  > :
-  RCU_Op<mnemonic, traits>
-  , Arguments<(ins AnyType:$p)>
-  , Results<(outs AnyType:$result)> {
-    let summary = "An expansion of an rcu_dereference() macro variant";
+  : Kernel_Op<mnemonic, !listconcat(traits, [])> {
     let description = [{
       See https://www.kernel.org/doc/html/next/core-api/kernel-api.html
     }];
+}
+
+class RCU_Unary_Op<string mnemonic, list<Trait> traits = []>
+  : RCU_Op<mnemonic, !listconcat(traits,
+    [DeclareOpInterfaceMethods<RCU_Macro_Interface>])>
+  , Arguments<(ins AnyType:$p)>
+  , Results<(outs AnyType:$result)> {
+    let summary = "An expansion of an RCU macro with one paramter, p";
     let assemblyFormat = [{
-    `(` $p `)` attr-dict
-    `:` functional-type( operands, results )
-  }];
+      `(` $p `)` attr-dict
+      `:` functional-type( operands, results )
+    }];
+}
+
+def RCUAccessPointer : RCU_Unary_Op<"rcu_access_pointer">;
+
+class RCU_Deference_Op<string mnemonic, list<Trait> traits = []> :
+  RCU_Unary_Op<mnemonic, !listconcat(traits,
+    [DeclareOpInterfaceMethods<RCU_Dereference_Interface>])> {
+    let summary = "An expansion of an rcu_dereference() macro variant";
 }
 
 def RCUDereference : RCU_Deference_Op<"rcu_dereference">;
 def RCUDereferenceBH : RCU_Deference_Op<"rcu_dereference_bh">;
 def RCUDereferenceSched : RCU_Deference_Op<"rcu_dereference_sched">;
-def RCUAccessPointer : RCU_Deference_Op<"rcu_access_pointer">;
 
-class RCU_Deference_Check_Op<
-  string mnemonic
-  , list<Trait>
-  traits = [DeclareOpInterfaceMethods<RCU_Macro_Interface>]
-  > :
-  RCU_Op<mnemonic, traits>
+class RCU_Deference_Check_Op<string mnemonic, list<Trait> traits = []>
+  : RCU_Op<mnemonic, !listconcat(traits,
+  [DeclareOpInterfaceMethods<RCU_Macro_Interface>])>
   , Arguments<(ins
     AnyType:$p,
     AnyType:$c)>

--- a/include/macroni/Dialect/Kernel/KernelOps.td
+++ b/include/macroni/Dialect/Kernel/KernelOps.td
@@ -6,10 +6,12 @@
 include "mlir/IR/BuiltinTypes.td"
 include "mlir/IR/OpBase.td"
 
+include "macroni/Dialect/Kernel/KernelInterfaces.td"
+
 /* Special macros */
 
 def GetUser :
-  Kernel_Op< "get_user", [] >
+  Kernel_Op<"get_user">
   , Arguments<(ins
     AnyType:$x,
     AnyType:$ptr
@@ -21,15 +23,17 @@ def GetUser :
     space. It accepts two arguments:
     - x: A variable in which to store the result.
     - ptr: A source address in user space.
-    get_user returns zero on success, or -EFAULT on error.
+    et_user returns zero on success, or -EFAULT on error.
 
     More information: https://www.cs.bham.ac.uk/~exr/lectures/opsys/12_13/docs/kernelAPI/r3776.html
   }];
-  let assemblyFormat = "`get_user` `(` $x `,` $ptr `)` attr-dict `:` functional-type( operands, results )";
+  let assemblyFormat = [{
+    `(` $x `,` $ptr `)` attr-dict `:` functional-type( operands, results )
+  }];
 }
 
 def OffsetOf :
-  Kernel_Op< "offsetof", [] >
+  Kernel_Op<"offsetof">
   , Arguments<(ins
     TypeAttr:$type,
     StrAttr:$member
@@ -51,11 +55,13 @@ def OffsetOf :
 
     More information: https://man7.org/linux/man-pages/man3/offsetof.3.html
   }];
-  let assemblyFormat = "`offsetof` `(` $type `,` $member `)` attr-dict `:` functional-type( operands, results )";
+  let assemblyFormat = [{
+    `(` $type `,` $member `)` attr-dict `:` functional-type( operands, results )
+  }];
 }
 
 def ContainerOf :
-  Kernel_Op< "container_of", [] >
+  Kernel_Op<"container_of">
   , Arguments<(ins
     AnyType:$ptr,
     TypeAttr:$type,
@@ -69,13 +75,13 @@ def ContainerOf :
      member.
   }];
   let assemblyFormat = [{
-    `container_of` `(` $ptr `,` $type `,` $member `)`
+    `(` $ptr `,` $type `,` $member `)`
     attr-dict `:` functional-type( operands, results )
   }];
 }
 
 def ListForEach :
-  Kernel_Op< "list_for_each()", [SingleBlock, NoTerminator] >
+  Kernel_Op<"list_for_each()", [SingleBlock, NoTerminator] >
   , Arguments<(ins
     AnyType:$pos,
     AnyType:$head
@@ -95,12 +101,24 @@ def ListForEach :
       "std::unique_ptr< mlir::Region > &&":$bodyRegion
     )>
   ];
-  let assemblyFormat = "`list_for_each` `(` $pos `,` $head `)` attr-dict `:` functional-type( operands, results ) $bodyRegion";
+  let assemblyFormat = [{
+    `(` $pos `,` $head `)` attr-dict
+    `:` functional-type( operands, results ) $bodyRegion
+  }];
+}
+
+def SMPMB :
+  Kernel_Op<"smp_mb">
+  , Results<(outs AnyType:$result)> {
+  let summary = "An expansion of the Linux kernel macro, smp_mb()";
+  let description = "smp_mb() activates a memory barrier";
+  let assemblyFormat = [{
+    `(` `)` attr-dict `:` functional-type( operands, results )
+  }];
 }
 
 def RCUCriticalSection :
-  Kernel_Op< "rcu.critical_section", [NoTerminator] >
-{
+  Kernel_Op<"rcu.critical_section", [NoTerminator] > {
   let summary = "An RCU critical section";
   let description = [{
     An RCU critical section denoted by an rcu_read_lock() and rcu_read_unlock()
@@ -111,158 +129,63 @@ def RCUCriticalSection :
   let assemblyFormat = "$bodyRegion attr-dict";
 }
 
-def RCUDereference :
-  Kernel_Op< "rcu_dereference", [] >
+/* RCU macros */
+
+class RCU_Op<string mnemonic, list<Trait> traits = []>
+  : Kernel_Op<mnemonic, traits>;
+
+class RCU_Deference_Op<
+  string mnemonic
+  , list<Trait>
+    traits = [DeclareOpInterfaceMethods<RCU_Macro_Interface>]
+  > :
+  RCU_Op<mnemonic, traits>
   , Arguments<(ins AnyType:$p)>
   , Results<(outs AnyType:$result)> {
-  let summary = "An expansion of the Linux kernel macro, rcu_dereference()";
-  let description = [{
-    rcu_dereference() - fetch RCU-protected pointer for dereferencing
-    @p: The pointer to read, prior to dereferencing
-    See https://www.kernel.org/doc/html/next/core-api/kernel-api.html
-  }];
-  let assemblyFormat = [{
-    `rcu_dereference` `(` $p `)` attr-dict
+    let summary = "An expansion of an rcu_dereference() macro variant";
+    let description = [{
+      See https://www.kernel.org/doc/html/next/core-api/kernel-api.html
+    }];
+    let assemblyFormat = [{
+    `(` $p `)` attr-dict
     `:` functional-type( operands, results )
   }];
 }
 
-def RCUDereferenceBH :
-  Kernel_Op< "rcu_dereference_bh", [] >
-  , Arguments<(ins AnyType:$p)>
-  , Results<(outs AnyType:$result)> {
-  let summary = "An expansion of the Linux kernel macro, rcu_dereference_bh()";
-  let description = [{
-    rcu_dereference_bh() - fetch an RCU-bh-protected pointer for dereferencing
-    @p: The pointer to read, prior to dereferencing
-    See https://www.kernel.org/doc/html/next/core-api/kernel-api.html
-  }];
-  let assemblyFormat = [{
-    `rcu_dereference_bh` `(` $p `)` attr-dict
-    `:` functional-type( operands, results )
-  }];
-}
+def RCUDereference : RCU_Deference_Op<"rcu_dereference">;
+def RCUDereferenceBH : RCU_Deference_Op<"rcu_dereference_bh">;
+def RCUDereferenceSched : RCU_Deference_Op<"rcu_dereference_sched">;
+def RCUAccessPointer : RCU_Deference_Op<"rcu_access_pointer">;
 
-def RCUDereferenceSched :
-  Kernel_Op< "rcu_dereference_sched", [] >
-  , Arguments<(ins AnyType:$p)>
-  , Results<(outs AnyType:$result)> {
-  let summary = "An expansion of the Linux kernel macro, rcu_dereference_sched()";
-  let description = [{
-    rcu_dereference_sched() - fetch RCU-sched-protected pointer for dereferencing
-    @p: The pointer to read, prior to dereferencing
-    See https://www.kernel.org/doc/html/next/core-api/kernel-api.html
-  }];
-  let assemblyFormat = [{
-    `rcu_dereference_sched` `(` $p `)` attr-dict
-    `:` functional-type( operands, results )
-  }];
-}
-
-def RCUDereferenceCheck :
-  Kernel_Op< "rcu_dereference_check", [] >
+class RCU_Deference_Check_Op<
+  string mnemonic
+  , list<Trait>
+  traits = [DeclareOpInterfaceMethods<RCU_Macro_Interface>]
+  > :
+  RCU_Op<mnemonic, traits>
   , Arguments<(ins
     AnyType:$p,
     AnyType:$c)>
   , Results<(outs AnyType:$result)> {
-  let summary = [{
-    An expansion of the Linux kernel macro, rcu_dereference_check()
-  }];
-  let description = [{
-    rcu_dereference_check() - rcu_dereference with debug checking
-    @p: The pointer to read, prior to dereferencing
-    @c: The conditions under which the dereference will take place
-    See https://www.kernel.org/doc/html/next/core-api/kernel-api.html
-  }];
-  let assemblyFormat = [{
-    `rcu_dereference_check` `(` $p `,` $c `)` attr-dict
-    `:` functional-type( operands, results )
-  }];
+    let summary = "An expansion of an rcu_dereference_check() macro variant";
+    let description = [{
+      See https://www.kernel.org/doc/html/next/core-api/kernel-api.html
+    }];
+    let assemblyFormat = [{
+      `(` $p `,` $c `)` attr-dict
+      `:` functional-type( operands, results )
+    }];
 }
 
-def RCUDereferenceBHCheck :
-  Kernel_Op< "rcu_dereference_bh_check", [] >
-  , Arguments<(ins
-    AnyType:$p,
-    AnyType:$c)>
-  , Results<(outs AnyType:$result)> {
-  let summary = [{
-    An expansion of the Linux kernel macro, rcu_dereference_bh_check()
-  }];
-  let description = [{
-    rcu_dereference_bh_check() - rcu_dereference_bh with debug checking
-    @p: The pointer to read, prior to dereferencing
-    @c: The conditions under which the dereference will take place
-    See https://www.kernel.org/doc/html/next/core-api/kernel-api.html
-  }];
-  let assemblyFormat = [{
-    `rcu_dereference_bh_check` `(` $p `,` $c `)` attr-dict
-    `:` functional-type( operands, results )
-  }];
-}
-
+def RCUDereferenceCheck : RCU_Deference_Check_Op<"rcu_dereference_check">;
+def RCUDereferenceBHCheck : RCU_Deference_Check_Op<"rcu_dereference_bh_check">;
 def RCUDereferenceSchedCheck :
-  Kernel_Op< "rcu_dereference_sched_check", [] >
-  , Arguments<(ins
-    AnyType:$p,
-    AnyType:$c)>
-  , Results<(outs AnyType:$result)> {
-  let summary = [{
-    An expansion of the Linux kernel macro, rcu_dereference_sched_check()
-  }];
-  let description = [{
-    rcu_dereference_sched_check() - rcu_dereference_sched with debug checking
-    @p: The pointer to read, prior to dereferencing
-    @c: The conditions under which the dereference will take place
-    See https://www.kernel.org/doc/html/next/core-api/kernel-api.html
-  }];
-  let assemblyFormat = [{
-    `rcu_dereference_sched_check` `(` $p `,` $c `)` attr-dict
-    `:` functional-type( operands, results )
-  }];
-}
-
+  RCU_Deference_Check_Op<"rcu_dereference_sched_check">;
 def RCUDereferenceProtected :
-  Kernel_Op< "rcu_dereference_protected", [] >
-  , Arguments<(ins
-    AnyType:$p,
-    AnyType:$c)>
-  , Results<(outs AnyType:$result)> {
-  let summary = [{
-    An expansion of the Linux kernel macro, rcu_dereference_protected()
-  }];
-  let description = [{
-    rcu_dereference_protected() - fetch RCU pointer when updates prevented
-    @p: The pointer to read, prior to dereferencing
-    @c: The conditions under which the dereference will take place
-    See https://www.kernel.org/doc/html/next/core-api/kernel-api.html
-  }];
-  let assemblyFormat = [{
-    `rcu_dereference_protected` `(` $p `,` $c `)` attr-dict
-    `:` functional-type( operands, results )
-  }];
-}
-
-def RCUAccessPointer :
-  Kernel_Op< "rcu_access_pointer", [] >
-  , Arguments<(ins AnyType:$p)>
-  , Results<(outs AnyType:$result)> {
-  let summary = [{
-    An expansion of the Linux kernel macro, rcu_access_pointer()
-  }];
-  let description = [{
-    rcu_access_pointer() - fetch RCU pointer with no dereferencing 
-    @p: The pointer to read
-    See https://www.kernel.org/doc/html/next/core-api/kernel-api.html
-  }];
-  let assemblyFormat = [{
-    `rcu_access_pointer` `(` $p `)` attr-dict
-    `:` functional-type( operands, results )
-  }];
-}
+  RCU_Deference_Check_Op<"rcu_dereference_protected">;
 
 def RCUAssignPointer :
-  Kernel_Op< "rcu_assign_pointer", [] >
+  RCU_Op<"rcu_assign_pointer">
   , Arguments<(ins
     AnyType:$p
     , AnyType:$v)>
@@ -271,19 +194,16 @@ def RCUAssignPointer :
     An expansion of the Linux kernel macro, rcu_assign_pointer()
   }];
   let description = [{
-    rcu_assign_pointer() - assign to RCU-protected pointer
-    @p: The pointer to read
-    @v: The value to statically initialize with.
     See https://www.kernel.org/doc/html/next/core-api/kernel-api.html
   }];
   let assemblyFormat = [{
-    `rcu_assign_pointer` `(` $p `,` $v `)` attr-dict
+    `(` $p `,` $v `)` attr-dict
     `:` functional-type( operands, results )
   }];
 }
 
 def RCUReplacePointer :
-  Kernel_Op< "rcu_replace_pointer", [] >
+  RCU_Op<"rcu_replace_pointer">
   , Arguments<(ins
     AnyType:$rcu_ptr
     , AnyType:$ptr
@@ -293,25 +213,11 @@ def RCUReplacePointer :
     An expansion of the Linux kernel macro, rcu_replace_pointer()
   }];
   let description = [{
-    rcu_replace_pointer() - replace an RCU pointer, returning its old value
-    @rcu_ptr: RCU pointer, whose old value is returned
-    @ptr: regular pointer
-    @c: the lockdep conditions under which the dereference will take place
     See https://www.kernel.org/doc/html/next/core-api/kernel-api.html
   }];
   let assemblyFormat = [{
-    `rcu_replace_pointer` `(` $rcu_ptr `,` $ptr `,` $c `)` attr-dict
+    `(` $rcu_ptr `,` $ptr `,` $c `)` attr-dict
     `:` functional-type( operands, results )
-  }];
-}
-
-def SMPMB :
-  Kernel_Op< "smp_mb", [] >
-  , Results<(outs AnyType:$result)> {
-  let summary = "An expansion of the Linux kernel macro, smp_mb()";
-  let description = "smp_mb() activates a memory barrier";
-  let assemblyFormat = [{
-    `smp_mb` `(` `)` attr-dict `:` functional-type( operands, results )
   }];
 }
 

--- a/include/macroni/Dialect/Kernel/KernelTypes.hpp
+++ b/include/macroni/Dialect/Kernel/KernelTypes.hpp
@@ -15,5 +15,8 @@ VAST_RELAX_WARNINGS
 #include <mlir/Interfaces/DataLayoutInterfaces.h>
 VAST_UNRELAX_WARNINGS
 
+#include <macroni/Dialect/Kernel/KernelAttributes.hpp>
+#include <macroni/Dialect/Kernel/KernelInterfaces.hpp>
+
 #define GET_TYPEDEF_CLASSES
 #include "macroni/Dialect/Kernel/KernelTypes.h.inc"

--- a/include/macroni/Dialect/Kernel/KernelTypes.td
+++ b/include/macroni/Dialect/Kernel/KernelTypes.td
@@ -4,6 +4,8 @@
 include "mlir/Interfaces/DataLayoutInterfaces.td"
 include "mlir/IR/BuiltinTypeInterfaces.td"
 
+include "macroni/Dialect/Kernel/KernelAttributes.td"
+
 //
 // Generic kernel type
 //

--- a/include/macroni/Translation/MacroniCodeGenVisitorMixin.hpp
+++ b/include/macroni/Translation/MacroniCodeGenVisitorMixin.hpp
@@ -109,8 +109,8 @@ struct MacroniCodeGenVisitorMixin
     // vast::cg::codegen_instance expects a vast::cg::meta_generator as its meta
     // generator, but we use static inheritance to pass it our own meta
     // generator, so simply calling location() directly won't work.
-    auto loc =
-        dynamic_cast<MacroniMetaGenerator &>(derived().meta).location(*sub);
+    auto meta = dynamic_cast<MacroniMetaGenerator *>(&derived().meta);
+    auto loc = meta ? meta->location(*sub) : mlir::UnknownLoc();
     auto name_tok = sub->NameOrOperator();
     auto macro_name = (name_tok ? name_tok->Data() : "<a nameless macro>");
     auto function_like = is_sub_function_like(*sub);

--- a/include/macroni/Translation/MacroniMetaGenerator.hpp
+++ b/include/macroni/Translation/MacroniMetaGenerator.hpp
@@ -47,10 +47,11 @@ public:
     return unknown_location;
   }
 
-  mlir::Location location(pasta::MacroSubstitution &sub) const {
-    // TODO(bpp): Define this to something that makes sense. Right now this just
-    // returns an invalid source location.
-    return unknown_location;
+  mlir::Location location(pasta::MacroSubstitution sub) const {
+    return mlir::FileLineColLoc::get(
+        mlir::StringAttr::get(mctx, llvm::Twine("<macroni-input>")),
+        sub.BeginToken()->FileLocation()->Line(),
+        sub.BeginToken()->FileLocation()->Column());
   }
 
   clang::ASTContext *ast;

--- a/include/macroni/Translation/MacroniMetaGenerator.hpp
+++ b/include/macroni/Translation/MacroniMetaGenerator.hpp
@@ -48,10 +48,13 @@ public:
   }
 
   mlir::Location location(pasta::MacroSubstitution sub) const {
+    auto begin_token = sub.BeginToken();
+    auto file_loc = begin_token ? begin_token->FileLocation() : std::nullopt;
+    auto file = file_loc ? pasta::File::Containing(file_loc) : std::nullopt;
+    auto filepath = file ? file->Path().string() : "<unknown>";
     return mlir::FileLineColLoc::get(
-        mlir::StringAttr::get(mctx, llvm::Twine("<macroni-input>")),
-        sub.BeginToken()->FileLocation()->Line(),
-        sub.BeginToken()->FileLocation()->Column());
+        mlir::StringAttr::get(mctx, llvm::Twine(filepath)),
+        file_loc ? file_loc->Line() : 0, file_loc ? file_loc->Column() : 0);
   }
 
   clang::ASTContext *ast;

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -12,9 +12,9 @@ add_library(macroni_api INTERFACE)
 
 target_link_libraries(macroni_api
     INTERFACE
+        macroni_settings
         macroni_common
         macroni_translation_api
-        macroni_settings
 )
 
 add_library(macroni::api ALIAS macroni_api)

--- a/lib/macroni/Conversion/Kernel/KernelRewriters.cpp
+++ b/lib/macroni/Conversion/Kernel/KernelRewriters.cpp
@@ -79,7 +79,7 @@ std::array<mlir::Operation *, sizeof...(Args)>
 fetch_macro_parameters(mlir::Operation *op, Args &&...args) {
   auto results = std::array<mlir::Operation *, sizeof...(Args)>();
   auto walker = [&](macroni::MacroParameter mp) {
-    for (auto result : results) {
+    for (auto &result : results) {
       fetch_macro_params_helper(mp, result, args...);
     }
   };

--- a/lib/macroni/Conversion/Kernel/KernelRewriters.cpp
+++ b/lib/macroni/Conversion/Kernel/KernelRewriters.cpp
@@ -79,7 +79,7 @@ std::array<mlir::Operation *, sizeof...(Args)>
 fetch_macro_parameters(mlir::Operation *op, Args &&...args) {
   auto results = std::array<mlir::Operation *, sizeof...(Args)>();
   auto walker = [&](macroni::MacroParameter mp) {
-    for (auto &&result : results) {
+    for (auto result : results) {
       fetch_macro_params_helper(mp, result, args...);
     }
   };

--- a/lib/macroni/Dialect/Kernel/CMakeLists.txt
+++ b/lib/macroni/Dialect/Kernel/CMakeLists.txt
@@ -2,14 +2,18 @@
 
 add_mlir_dialect_library(MLIRKernel
     KernelDialect.cpp
+    KernelInterfaces.cpp
     KernelOps.cpp
+    KernelAttributes.cpp
     KernelTypes.cpp
 
     ADDITIONAL_HEADER_DIRS
         ${PROJECT_SOURCE_DIR}/include
 
     DEPENDS
+        MLIRKernelAttributesIncGen
         MLIRKernelIncGen
+        MLIRKernelInterfacesIncGen
 
     LINK_LIBS PUBLIC
         MLIRIR

--- a/lib/macroni/Dialect/Kernel/KernelAttributes.cpp
+++ b/lib/macroni/Dialect/Kernel/KernelAttributes.cpp
@@ -1,0 +1,24 @@
+// Copyright (c) 2023-present, Trail of Bits, Inc.
+
+#include <macroni/Dialect/Kernel/KernelAttributes.hpp>
+#include <macroni/Dialect/Kernel/KernelTypes.hpp>
+
+#include <vast/Util/Warnings.hpp>
+
+VAST_RELAX_WARNINGS
+#include <llvm/ADT/TypeSwitch.h>
+#include <mlir/IR/DialectImplementation.h>
+#include <mlir/IR/OpImplementation.h>
+VAST_RELAX_WARNINGS
+
+#define GET_ATTRDEF_CLASSES
+#include <macroni/Dialect/Kernel/KernelAttributes.cpp.inc>
+
+namespace macroni::kernel {
+void KernelDialect::registerAttributes() {
+  addAttributes<
+#define GET_ATTRDEF_LIST
+#include <macroni/Dialect/Kernel/KernelAttributes.cpp.inc>
+      >();
+}
+} // namespace macroni::kernel

--- a/lib/macroni/Dialect/Kernel/KernelDialect.cpp
+++ b/lib/macroni/Dialect/Kernel/KernelDialect.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) 2023-present, Trail of Bits, Inc.
 
-#include "macroni/Dialect/Kernel/KernelDialect.hpp"
+#include "macroni/Dialect/Kernel/KernelAttributes.hpp"
+#include "macroni/Dialect/Kernel/KernelTypes.hpp"
+#include "macroni/Dialect/Kernel/KernelInterfaces.hpp"
 #include "macroni/Dialect/Kernel/KernelOps.hpp"
 
 #include <mlir/IR/Builders.h>
@@ -13,6 +15,7 @@
 
 namespace macroni::kernel {
 void KernelDialect::initialize() {
+  registerAttributes();
   registerTypes();
 
   addOperations<

--- a/lib/macroni/Dialect/Kernel/KernelInterfaces.cpp
+++ b/lib/macroni/Dialect/Kernel/KernelInterfaces.cpp
@@ -1,0 +1,10 @@
+// Copyright (c) 2024-present, Trail of Bits, Inc.
+
+#include <macroni/Dialect/Kernel/KernelInterfaces.hpp>
+
+//===----------------------------------------------------------------------===//
+// Alias Type Interface
+//===----------------------------------------------------------------------===//
+
+/// Include the generated interface.
+#include <macroni/Dialect/Kernel/KernelInterfaces.cpp.inc>

--- a/lib/macroni/Dialect/Kernel/KernelOps.cpp
+++ b/lib/macroni/Dialect/Kernel/KernelOps.cpp
@@ -1,5 +1,8 @@
 // Copyright (c) 2023-present, Trail of Bits, Inc.
 
+#include "macroni/Dialect/Kernel/KernelAttributes.hpp"
+#include <macroni/Dialect/Kernel/KernelTypes.hpp>
+#include <macroni/Dialect/Kernel/KernelInterfaces.hpp>
 #include "macroni/Dialect/Kernel/KernelOps.hpp"
 #include "macroni/Dialect/Kernel/KernelDialect.hpp"
 

--- a/lib/macroni/Dialect/Kernel/KernelTypes.cpp
+++ b/lib/macroni/Dialect/Kernel/KernelTypes.cpp
@@ -1,5 +1,7 @@
 #include <llvm/ADT/TypeSwitch.h>
+#include <macroni/Dialect/Kernel/KernelAttributes.hpp>
 #include <macroni/Dialect/Kernel/KernelDialect.hpp>
+#include <macroni/Dialect/Kernel/KernelInterfaces.hpp>
 #include <macroni/Dialect/Kernel/KernelOps.hpp>
 #include <macroni/Dialect/Kernel/KernelTypes.hpp>
 #include <mlir/IR/DialectImplementation.h>

--- a/test/KernelTests/address_space_attr.c
+++ b/test/KernelTests/address_space_attr.c
@@ -1,33 +1,34 @@
 // RUN: kernelize -x c %s | FileCheck %s --match-full-lines
 
-// CHECK: hl.translation_unit {
-// CHECK:   hl.typedef "__int128_t" : !hl.int128
-// CHECK:   hl.typedef "__uint128_t" : !hl.int128< unsigned >
-// CHECK:   hl.struct "__NSConstantString_tag" : {
-// CHECK:     hl.field "isa" : !hl.ptr<!hl.int< const >>
-// CHECK:     hl.field "flags" : !hl.int
-// CHECK:     hl.field "str" : !hl.ptr<!hl.char< const >>
-// CHECK:     hl.field "length" : !hl.long
-// CHECK:   }
-// CHECK:   hl.typedef "__NSConstantString" : !hl.record<"__NSConstantString_tag">
-// CHECK:   hl.typedef "__builtin_ms_va_list" : !hl.ptr<!hl.char>
-// CHECK:   hl.struct "__va_list_tag" : {
-// CHECK:     hl.field "gp_offset" : !hl.int< unsigned >
-// CHECK:     hl.field "fp_offset" : !hl.int< unsigned >
-// CHECK:     hl.field "overflow_arg_area" : !hl.ptr<!hl.void>
-// CHECK:     hl.field "reg_save_area" : !hl.ptr<!hl.void>
-// CHECK:   }
-// CHECK:   hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
-// CHECK:   %0 = hl.var "a" : !hl.lvalue<!kernel<address_space(0) <!hl.attributed<!hl.int>>>>
-// CHECK:   %1 = hl.var "b" : !hl.lvalue<!kernel<address_space(1) <!hl.attributed<!hl.int>>>>
-// CHECK:   %2 = hl.var "c" : !hl.lvalue<!kernel<address_space(2) <!hl.attributed<!hl.int>>>>
-// CHECK:   %3 = hl.var "d" : !hl.lvalue<!kernel<address_space(3) <!hl.attributed<!hl.int>>>>
-// CHECK:   %4 = hl.var "e" : !hl.lvalue<!kernel<address_space(4) <!hl.attributed<!hl.int>>>>
-// CHECK: }
-
 #define addr_space(x)   __attribute__((address_space(x)))
 int a addr_space(0);
 int b addr_space(1);
 int c addr_space(2);
 int d addr_space(3);
 int e addr_space(4);
+
+// CHECK:hl.translation_unit {
+// CHECK:  hl.typedef "__int128_t" : !hl.int128
+// CHECK:  hl.typedef "__uint128_t" : !hl.int128< unsigned >
+// CHECK:  hl.struct "__NSConstantString_tag" {type_visibility = #unsup<attr "type_visibility">} : {
+// CHECK:    hl.field "isa" : !hl.ptr<!hl.int< const >>
+// CHECK:    hl.field "flags" : !hl.int
+// CHECK:    hl.field "str" : !hl.ptr<!hl.char< const >>
+// CHECK:    hl.field "length" : !hl.long
+// CHECK:  }
+// CHECK:  hl.typedef "__NSConstantString" : !hl.record<"__NSConstantString_tag">
+// CHECK:  hl.typedef "__builtin_ms_va_list" : !hl.ptr<!hl.char>
+// CHECK:  hl.struct "__va_list_tag" {type_visibility = #unsup<attr "type_visibility">} : {
+// CHECK:    hl.field "gp_offset" : !hl.int< unsigned >
+// CHECK:    hl.field "fp_offset" : !hl.int< unsigned >
+// CHECK:    hl.field "overflow_arg_area" : !hl.ptr<!hl.void>
+// CHECK:    hl.field "reg_save_area" : !hl.ptr<!hl.void>
+// CHECK:  }
+// CHECK:  hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
+// CHECK:  %0 = hl.var "a" : !hl.lvalue<!kernel<address_space(0) <!hl.attributed<!hl.int>>>>
+// CHECK:  %1 = hl.var "b" : !hl.lvalue<!kernel<address_space(1) <!hl.attributed<!hl.int>>>>
+// CHECK:  %2 = hl.var "c" : !hl.lvalue<!kernel<address_space(2) <!hl.attributed<!hl.int>>>>
+// CHECK:  %3 = hl.var "d" : !hl.lvalue<!kernel<address_space(3) <!hl.attributed<!hl.int>>>>
+// CHECK:  %4 = hl.var "e" : !hl.lvalue<!kernel<address_space(4) <!hl.attributed<!hl.int>>>>
+// CHECK:}
+

--- a/test/KernelTests/container_of.c
+++ b/test/KernelTests/container_of.c
@@ -1,47 +1,5 @@
 // RUN: kernelize -x c %s | FileCheck %s --match-full-lines
 
-// CHECK: hl.translation_unit {
-// CHECK:   hl.typedef "__int128_t" : !hl.int128
-// CHECK:   hl.typedef "__uint128_t" : !hl.int128< unsigned >
-// CHECK:   hl.struct "__NSConstantString_tag" : {
-// CHECK:     hl.field "isa" : !hl.ptr<!hl.int< const >>
-// CHECK:     hl.field "flags" : !hl.int
-// CHECK:     hl.field "str" : !hl.ptr<!hl.char< const >>
-// CHECK:     hl.field "length" : !hl.long
-// CHECK:   }
-// CHECK:   hl.typedef "__NSConstantString" : !hl.record<"__NSConstantString_tag">
-// CHECK:   hl.typedef "__builtin_ms_va_list" : !hl.ptr<!hl.char>
-// CHECK:   hl.struct "__va_list_tag" : {
-// CHECK:     hl.field "gp_offset" : !hl.int< unsigned >
-// CHECK:     hl.field "fp_offset" : !hl.int< unsigned >
-// CHECK:     hl.field "overflow_arg_area" : !hl.ptr<!hl.void>
-// CHECK:     hl.field "reg_save_area" : !hl.ptr<!hl.void>
-// CHECK:   }
-// CHECK:   hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
-// CHECK:   hl.typedef "size_t" : !hl.long< unsigned >
-// CHECK:   hl.struct "contained" : {
-// CHECK:   }
-// CHECK:   hl.struct "container" : {
-// CHECK:     hl.field "contained_member" : !hl.ptr<!hl.elaborated<!hl.record<"contained">>>
-// CHECK:   }
-// CHECK:   hl.func @main () -> !hl.int {
-// CHECK:     core.scope {
-// CHECK:       %0 = hl.var "container_instance" : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"container">>>>
-// CHECK:       %1 = macroni.parameter "ptr" : !hl.ptr<!hl.ptr<!hl.elaborated<!hl.record<"contained">>>> {
-// CHECK:         %4 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"container">>>>) -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"container">>>>
-// CHECK:         %5 = hl.implicit_cast %4 LValueToRValue : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"container">>>> -> !hl.ptr<!hl.elaborated<!hl.record<"container">>>
-// CHECK:         %6 = hl.member %5 at "contained_member" : !hl.ptr<!hl.elaborated<!hl.record<"container">>> -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"contained">>>>
-// CHECK:         %7 = hl.addressof %6 : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"contained">>>> -> !hl.ptr<!hl.ptr<!hl.elaborated<!hl.record<"contained">>>>
-// CHECK:         hl.value.yield %7 : !hl.ptr<!hl.ptr<!hl.elaborated<!hl.record<"contained">>>>
-// CHECK:       }
-// CHECK:       %2 = kernel.container_of container_of(%1, !hl.elaborated<!hl.record<"container">>, "contained_member") : (!hl.ptr<!hl.ptr<!hl.elaborated<!hl.record<"contained">>>>) -> !hl.ptr<!hl.elaborated<!hl.record<"container">>>
-// CHECK:       %3 = hl.const #core.integer<0> : !hl.int
-// CHECK:       hl.return %3 : !hl.int
-// CHECK:     }
-// CHECK:   }
-// CHECK: }
-
-
 typedef unsigned long size_t;
 
 #define offsetof(TYPE, MEMBER) ((size_t) &((TYPE *)0)->MEMBER)
@@ -61,3 +19,45 @@ int main(void) {
         container_of(&container_instance->contained_member, struct container, contained_member);
         return 0;
 }
+
+// CHECK:hl.translation_unit {
+// CHECK:  hl.typedef "__int128_t" : !hl.int128
+// CHECK:  hl.typedef "__uint128_t" : !hl.int128< unsigned >
+// CHECK:  hl.struct "__NSConstantString_tag" {type_visibility = #unsup<attr "type_visibility">} : {
+// CHECK:    hl.field "isa" : !hl.ptr<!hl.int< const >>
+// CHECK:    hl.field "flags" : !hl.int
+// CHECK:    hl.field "str" : !hl.ptr<!hl.char< const >>
+// CHECK:    hl.field "length" : !hl.long
+// CHECK:  }
+// CHECK:  hl.typedef "__NSConstantString" : !hl.record<"__NSConstantString_tag">
+// CHECK:  hl.typedef "__builtin_ms_va_list" : !hl.ptr<!hl.char>
+// CHECK:  hl.struct "__va_list_tag" {type_visibility = #unsup<attr "type_visibility">} : {
+// CHECK:    hl.field "gp_offset" : !hl.int< unsigned >
+// CHECK:    hl.field "fp_offset" : !hl.int< unsigned >
+// CHECK:    hl.field "overflow_arg_area" : !hl.ptr<!hl.void>
+// CHECK:    hl.field "reg_save_area" : !hl.ptr<!hl.void>
+// CHECK:  }
+// CHECK:  hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
+// CHECK:  hl.typedef "size_t" : !hl.long< unsigned >
+// CHECK:  hl.struct "contained" : {
+// CHECK:  }
+// CHECK:  hl.struct "container" : {
+// CHECK:    hl.field "contained_member" : !hl.ptr<!hl.elaborated<!hl.record<"contained">>>
+// CHECK:  }
+// CHECK:  hl.func @main () -> !hl.int {
+// CHECK:    core.scope {
+// CHECK:      %0 = hl.var "container_instance" : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"container">>>>
+// CHECK:      %1 = macroni.parameter "ptr" : !hl.ptr<!hl.ptr<!hl.elaborated<!hl.record<"contained">>>> {
+// CHECK:        %4 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"container">>>>) -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"container">>>>
+// CHECK:        %5 = hl.implicit_cast %4 LValueToRValue : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"container">>>> -> !hl.ptr<!hl.elaborated<!hl.record<"container">>>
+// CHECK:        %6 = hl.member %5 at "contained_member" : !hl.ptr<!hl.elaborated<!hl.record<"container">>> -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"contained">>>>
+// CHECK:        %7 = hl.addressof %6 : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"contained">>>> -> !hl.ptr<!hl.ptr<!hl.elaborated<!hl.record<"contained">>>>
+// CHECK:        hl.value.yield %7 : !hl.ptr<!hl.ptr<!hl.elaborated<!hl.record<"contained">>>>
+// CHECK:      }
+// CHECK:      %2 = kernel.container_of(%1, !hl.elaborated<!hl.record<"container">>, "contained_member") : (!hl.ptr<!hl.ptr<!hl.elaborated<!hl.record<"contained">>>>) -> !hl.ptr<!hl.elaborated<!hl.record<"container">>>
+// CHECK:      %3 = hl.const #core.integer<0> : !hl.int
+// CHECK:      hl.return %3 : !hl.int
+// CHECK:    }
+// CHECK:  }
+// CHECK:}
+

--- a/test/KernelTests/get_user.c
+++ b/test/KernelTests/get_user.c
@@ -1,42 +1,5 @@
 // RUN: kernelize -x c %s | FileCheck %s --match-full-lines
 
-// CHECK: hl.translation_unit {
-// CHECK:   hl.typedef "__int128_t" : !hl.int128
-// CHECK:   hl.typedef "__uint128_t" : !hl.int128< unsigned >
-// CHECK:   hl.struct "__NSConstantString_tag" : {
-// CHECK:     hl.field "isa" : !hl.ptr<!hl.int< const >>
-// CHECK:     hl.field "flags" : !hl.int
-// CHECK:     hl.field "str" : !hl.ptr<!hl.char< const >>
-// CHECK:     hl.field "length" : !hl.long
-// CHECK:   }
-// CHECK:   hl.typedef "__NSConstantString" : !hl.record<"__NSConstantString_tag">
-// CHECK:   hl.typedef "__builtin_ms_va_list" : !hl.ptr<!hl.char>
-// CHECK:   hl.struct "__va_list_tag" : {
-// CHECK:     hl.field "gp_offset" : !hl.int< unsigned >
-// CHECK:     hl.field "fp_offset" : !hl.int< unsigned >
-// CHECK:     hl.field "overflow_arg_area" : !hl.ptr<!hl.void>
-// CHECK:     hl.field "reg_save_area" : !hl.ptr<!hl.void>
-// CHECK:   }
-// CHECK:   hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
-// CHECK:   hl.func @main () -> !hl.int {
-// CHECK:     core.scope {
-// CHECK:       %0 = hl.var "x" : !hl.lvalue<!hl.int>
-// CHECK:       %1 = hl.var "ptr" : !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:       %2 = macroni.parameter "x" : !hl.lvalue<!hl.int> {
-// CHECK:         %6 = hl.ref %0 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
-// CHECK:         hl.value.yield %6 : !hl.lvalue<!hl.int>
-// CHECK:       }
-// CHECK:       %3 = macroni.parameter "ptr" : !hl.lvalue<!hl.ptr<!hl.int>> {
-// CHECK:         %6 = hl.ref %1 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:         hl.value.yield %6 : !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:       }
-// CHECK:       %4 = kernel.get_user get_user(%2, %3) : (!hl.lvalue<!hl.int>, !hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.int
-// CHECK:       %5 = hl.const #core.integer<0> : !hl.int
-// CHECK:       hl.return %5 : !hl.int
-// CHECK:     }
-// CHECK:   }
-// CHECK: }
-
 #define get_user(x, ptr) ({ int res = 0; if (1) { x = *ptr; res = 1; } res; })
 
 int main(void) {
@@ -44,3 +7,41 @@ int main(void) {
         get_user(x, ptr);
         return 0;
 }
+
+// CHECK:hl.translation_unit {
+// CHECK:  hl.typedef "__int128_t" : !hl.int128
+// CHECK:  hl.typedef "__uint128_t" : !hl.int128< unsigned >
+// CHECK:  hl.struct "__NSConstantString_tag" {type_visibility = #unsup<attr "type_visibility">} : {
+// CHECK:    hl.field "isa" : !hl.ptr<!hl.int< const >>
+// CHECK:    hl.field "flags" : !hl.int
+// CHECK:    hl.field "str" : !hl.ptr<!hl.char< const >>
+// CHECK:    hl.field "length" : !hl.long
+// CHECK:  }
+// CHECK:  hl.typedef "__NSConstantString" : !hl.record<"__NSConstantString_tag">
+// CHECK:  hl.typedef "__builtin_ms_va_list" : !hl.ptr<!hl.char>
+// CHECK:  hl.struct "__va_list_tag" {type_visibility = #unsup<attr "type_visibility">} : {
+// CHECK:    hl.field "gp_offset" : !hl.int< unsigned >
+// CHECK:    hl.field "fp_offset" : !hl.int< unsigned >
+// CHECK:    hl.field "overflow_arg_area" : !hl.ptr<!hl.void>
+// CHECK:    hl.field "reg_save_area" : !hl.ptr<!hl.void>
+// CHECK:  }
+// CHECK:  hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
+// CHECK:  hl.func @main () -> !hl.int {
+// CHECK:    core.scope {
+// CHECK:      %0 = hl.var "x" : !hl.lvalue<!hl.int>
+// CHECK:      %1 = hl.var "ptr" : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:      %2 = macroni.parameter "ptr" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:        %6 = hl.ref %1 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:        hl.value.yield %6 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:      }
+// CHECK:      %3 = macroni.parameter "ptr" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:        %6 = hl.ref %1 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:        hl.value.yield %6 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:      }
+// CHECK:      %4 = kernel.get_user(%2, %3) : (!hl.lvalue<!hl.ptr<!hl.int>>, !hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.int
+// CHECK:      %5 = hl.const #core.integer<0> : !hl.int
+// CHECK:      hl.return %5 : !hl.int
+// CHECK:    }
+// CHECK:  }
+// CHECK:}
+

--- a/test/KernelTests/list_for_each.c
+++ b/test/KernelTests/list_for_each.c
@@ -1,84 +1,5 @@
 // RUN: kernelize -x c %s | FileCheck %s --match-full-lines
 
-// CHECK: hl.translation_unit {
-// CHECK:   hl.typedef "__int128_t" : !hl.int128
-// CHECK:   hl.typedef "__uint128_t" : !hl.int128< unsigned >
-// CHECK:   hl.struct "__NSConstantString_tag" : {
-// CHECK:     hl.field "isa" : !hl.ptr<!hl.int< const >>
-// CHECK:     hl.field "flags" : !hl.int
-// CHECK:     hl.field "str" : !hl.ptr<!hl.char< const >>
-// CHECK:     hl.field "length" : !hl.long
-// CHECK:   }
-// CHECK:   hl.typedef "__NSConstantString" : !hl.record<"__NSConstantString_tag">
-// CHECK:   hl.typedef "__builtin_ms_va_list" : !hl.ptr<!hl.char>
-// CHECK:   hl.struct "__va_list_tag" : {
-// CHECK:     hl.field "gp_offset" : !hl.int< unsigned >
-// CHECK:     hl.field "fp_offset" : !hl.int< unsigned >
-// CHECK:     hl.field "overflow_arg_area" : !hl.ptr<!hl.void>
-// CHECK:     hl.field "reg_save_area" : !hl.ptr<!hl.void>
-// CHECK:   }
-// CHECK:   hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
-// CHECK:   hl.typedef "size_t" : !hl.long< unsigned >
-// CHECK:   hl.struct "list_head" : {
-// CHECK:     hl.field "next" : !hl.ptr<!hl.elaborated<!hl.record<"list_head">>>
-// CHECK:     hl.field "prev" : !hl.ptr<!hl.elaborated<!hl.record<"list_head">>>
-// CHECK:   }
-// CHECK:   hl.func @list_is_head internal (%arg0: !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>>, %arg1: !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>>) -> !hl.int attributes {sym_visibility = "private"} {
-// CHECK:     core.scope {
-// CHECK:       %0 = hl.ref %arg0 : (!hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>>) -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>>
-// CHECK:       %1 = hl.implicit_cast %0 LValueToRValue : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>> -> !hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>
-// CHECK:       %2 = hl.ref %arg1 : (!hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>>) -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>>
-// CHECK:       %3 = hl.implicit_cast %2 LValueToRValue : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>> -> !hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>
-// CHECK:       %4 = hl.cmp eq %1, %3 : !hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>, !hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >> -> !hl.int
-// CHECK:       hl.return %4 : !hl.int
-// CHECK:     }
-// CHECK:   }
-// CHECK:   hl.func @main () -> !hl.int {
-// CHECK:     core.scope {
-// CHECK:       %0 = hl.var "head" : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
-// CHECK:       %1 = hl.var "pos" : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
-// CHECK:       core.scope {
-// CHECK:         %3 = macroni.parameter "pos" : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>> {
-// CHECK:           %11 = hl.ref %1 : (!hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>) -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
-// CHECK:           hl.value.yield %11 : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
-// CHECK:         }
-// CHECK:         %4 = hl.expr : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>> {
-// CHECK:           %11 = macroni.parameter "head" : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>> {
-// CHECK:             %12 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>) -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
-// CHECK:             hl.value.yield %12 : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
-// CHECK:           }
-// CHECK:           hl.value.yield %11 : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
-// CHECK:         }
-// CHECK:         %5 = hl.implicit_cast %4 LValueToRValue : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>> -> !hl.ptr<!hl.elaborated<!hl.record<"list_head">>>
-// CHECK:         %6 = hl.member %5 at "next" : !hl.ptr<!hl.elaborated<!hl.record<"list_head">>> -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
-// CHECK:         %7 = hl.implicit_cast %6 LValueToRValue : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>> -> !hl.ptr<!hl.elaborated<!hl.record<"list_head">>>
-// CHECK:         %8 = hl.assign %7 to %3 : !hl.ptr<!hl.elaborated<!hl.record<"list_head">>>, !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>> -> !hl.ptr<!hl.elaborated<!hl.record<"list_head">>>
-// CHECK:         %9 = macroni.parameter "pos" : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>> {
-// CHECK:           %11 = hl.ref %1 : (!hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>) -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
-// CHECK:           hl.value.yield %11 : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
-// CHECK:         }
-// CHECK:         %10 = macroni.parameter "head" : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>> {
-// CHECK:           %11 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>) -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
-// CHECK:           hl.value.yield %11 : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
-// CHECK:         }
-// CHECK:         kernel.list_for_each() list_for_each(%9, %10) : (!hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>, !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>) -> () {
-// CHECK:           core.scope {
-// CHECK:             %11 = hl.var "prev" : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>> = {
-// CHECK:               %12 = hl.ref %1 : (!hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>) -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
-// CHECK:               %13 = hl.implicit_cast %12 LValueToRValue : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>> -> !hl.ptr<!hl.elaborated<!hl.record<"list_head">>>
-// CHECK:               %14 = hl.member %13 at "prev" : !hl.ptr<!hl.elaborated<!hl.record<"list_head">>> -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
-// CHECK:               %15 = hl.implicit_cast %14 LValueToRValue : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>> -> !hl.ptr<!hl.elaborated<!hl.record<"list_head">>>
-// CHECK:               hl.value.yield %15 : !hl.ptr<!hl.elaborated<!hl.record<"list_head">>>
-// CHECK:             }
-// CHECK:           }
-// CHECK:         }
-// CHECK:       }
-// CHECK:       %2 = hl.const #core.integer<0> : !hl.int
-// CHECK:       hl.return %2 : !hl.int
-// CHECK:     }
-// CHECK:   }
-// CHECK: }
-
 typedef unsigned long size_t;
 
 struct list_head { struct list_head *next, *prev; };
@@ -98,3 +19,83 @@ int main(void) {
 	}
 	return 0;
 }
+
+// CHECK:hl.translation_unit {
+// CHECK:  hl.typedef "__int128_t" : !hl.int128
+// CHECK:  hl.typedef "__uint128_t" : !hl.int128< unsigned >
+// CHECK:  hl.struct "__NSConstantString_tag" {type_visibility = #unsup<attr "type_visibility">} : {
+// CHECK:    hl.field "isa" : !hl.ptr<!hl.int< const >>
+// CHECK:    hl.field "flags" : !hl.int
+// CHECK:    hl.field "str" : !hl.ptr<!hl.char< const >>
+// CHECK:    hl.field "length" : !hl.long
+// CHECK:  }
+// CHECK:  hl.typedef "__NSConstantString" : !hl.record<"__NSConstantString_tag">
+// CHECK:  hl.typedef "__builtin_ms_va_list" : !hl.ptr<!hl.char>
+// CHECK:  hl.struct "__va_list_tag" {type_visibility = #unsup<attr "type_visibility">} : {
+// CHECK:    hl.field "gp_offset" : !hl.int< unsigned >
+// CHECK:    hl.field "fp_offset" : !hl.int< unsigned >
+// CHECK:    hl.field "overflow_arg_area" : !hl.ptr<!hl.void>
+// CHECK:    hl.field "reg_save_area" : !hl.ptr<!hl.void>
+// CHECK:  }
+// CHECK:  hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
+// CHECK:  hl.typedef "size_t" : !hl.long< unsigned >
+// CHECK:  hl.struct "list_head" : {
+// CHECK:    hl.field "next" : !hl.ptr<!hl.elaborated<!hl.record<"list_head">>>
+// CHECK:    hl.field "prev" : !hl.ptr<!hl.elaborated<!hl.record<"list_head">>>
+// CHECK:  }
+// CHECK:  hl.func @list_is_head internal (%arg0: !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>>, %arg1: !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>>) -> !hl.int attributes {sym_visibility = "private"} {
+// CHECK:    core.scope {
+// CHECK:      %0 = hl.ref %arg0 : (!hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>>) -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>>
+// CHECK:      %1 = hl.implicit_cast %0 LValueToRValue : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>> -> !hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>
+// CHECK:      %2 = hl.ref %arg1 : (!hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>>) -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>>
+// CHECK:      %3 = hl.implicit_cast %2 LValueToRValue : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>> -> !hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>
+// CHECK:      %4 = hl.cmp eq %1, %3 : !hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >>, !hl.ptr<!hl.elaborated<!hl.record<"list_head">,  const >> -> !hl.int
+// CHECK:      hl.return %4 : !hl.int
+// CHECK:    }
+// CHECK:  }
+// CHECK:  hl.func @main () -> !hl.int {
+// CHECK:    core.scope {
+// CHECK:      %0 = hl.var "head" : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
+// CHECK:      %1 = hl.var "pos" : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
+// CHECK:      core.scope {
+// CHECK:        %3 = macroni.parameter "pos" : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>> {
+// CHECK:          %11 = hl.ref %1 : (!hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>) -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
+// CHECK:          hl.value.yield %11 : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
+// CHECK:        }
+// CHECK:        %4 = hl.expr : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>> {
+// CHECK:          %11 = macroni.parameter "head" : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>> {
+// CHECK:            %12 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>) -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
+// CHECK:            hl.value.yield %12 : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
+// CHECK:          }
+// CHECK:          hl.value.yield %11 : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
+// CHECK:        }
+// CHECK:        %5 = hl.implicit_cast %4 LValueToRValue : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>> -> !hl.ptr<!hl.elaborated<!hl.record<"list_head">>>
+// CHECK:        %6 = hl.member %5 at "next" : !hl.ptr<!hl.elaborated<!hl.record<"list_head">>> -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
+// CHECK:        %7 = hl.implicit_cast %6 LValueToRValue : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>> -> !hl.ptr<!hl.elaborated<!hl.record<"list_head">>>
+// CHECK:        %8 = hl.assign %7 to %3 : !hl.ptr<!hl.elaborated<!hl.record<"list_head">>>, !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>> -> !hl.ptr<!hl.elaborated<!hl.record<"list_head">>>
+// CHECK:        %9 = macroni.parameter "pos" : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>> {
+// CHECK:          %11 = hl.ref %1 : (!hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>) -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
+// CHECK:          hl.value.yield %11 : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
+// CHECK:        }
+// CHECK:        %10 = macroni.parameter "pos" : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>> {
+// CHECK:          %11 = hl.ref %1 : (!hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>) -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
+// CHECK:          hl.value.yield %11 : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
+// CHECK:        }
+// CHECK:        kernel.list_for_each()(%9, %10) : (!hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>, !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>) -> () {
+// CHECK:          core.scope {
+// CHECK:            %11 = hl.var "prev" : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>> = {
+// CHECK:              %12 = hl.ref %1 : (!hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>) -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
+// CHECK:              %13 = hl.implicit_cast %12 LValueToRValue : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>> -> !hl.ptr<!hl.elaborated<!hl.record<"list_head">>>
+// CHECK:              %14 = hl.member %13 at "prev" : !hl.ptr<!hl.elaborated<!hl.record<"list_head">>> -> !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>>
+// CHECK:              %15 = hl.implicit_cast %14 LValueToRValue : !hl.lvalue<!hl.ptr<!hl.elaborated<!hl.record<"list_head">>>> -> !hl.ptr<!hl.elaborated<!hl.record<"list_head">>>
+// CHECK:              hl.value.yield %15 : !hl.ptr<!hl.elaborated<!hl.record<"list_head">>>
+// CHECK:            }
+// CHECK:          }
+// CHECK:        }
+// CHECK:      }
+// CHECK:      %2 = hl.const #core.integer<0> : !hl.int
+// CHECK:      hl.return %2 : !hl.int
+// CHECK:    }
+// CHECK:  }
+// CHECK:}
+

--- a/test/KernelTests/offsetof.c
+++ b/test/KernelTests/offsetof.c
@@ -1,38 +1,5 @@
 // RUN: kernelize -x c %s | FileCheck %s --match-full-lines
 
-// CHECK: hl.translation_unit {
-// CHECK:   hl.typedef "__int128_t" : !hl.int128
-// CHECK:   hl.typedef "__uint128_t" : !hl.int128< unsigned >
-// CHECK:   hl.struct "__NSConstantString_tag" : {
-// CHECK:     hl.field "isa" : !hl.ptr<!hl.int< const >>
-// CHECK:     hl.field "flags" : !hl.int
-// CHECK:     hl.field "str" : !hl.ptr<!hl.char< const >>
-// CHECK:     hl.field "length" : !hl.long
-// CHECK:   }
-// CHECK:   hl.typedef "__NSConstantString" : !hl.record<"__NSConstantString_tag">
-// CHECK:   hl.typedef "__builtin_ms_va_list" : !hl.ptr<!hl.char>
-// CHECK:   hl.struct "__va_list_tag" : {
-// CHECK:     hl.field "gp_offset" : !hl.int< unsigned >
-// CHECK:     hl.field "fp_offset" : !hl.int< unsigned >
-// CHECK:     hl.field "overflow_arg_area" : !hl.ptr<!hl.void>
-// CHECK:     hl.field "reg_save_area" : !hl.ptr<!hl.void>
-// CHECK:   }
-// CHECK:   hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
-// CHECK:   hl.typedef "size_t" : !hl.long< unsigned >
-// CHECK:   hl.struct "location" : {
-// CHECK:     hl.field "file" : !hl.ptr<!hl.char>
-// CHECK:     hl.field "line" : !hl.int
-// CHECK:     hl.field "col" : !hl.int
-// CHECK:   }
-// CHECK:   hl.func @main () -> !hl.int {
-// CHECK:     core.scope {
-// CHECK:       %0 = kernel.offsetof offsetof(!hl.elaborated<!hl.record<"location">>, "line") : () -> !hl.elaborated<!hl.typedef<"size_t">>
-// CHECK:       %1 = hl.const #core.integer<0> : !hl.int
-// CHECK:       hl.return %1 : !hl.int
-// CHECK:     }
-// CHECK:   }
-// CHECK: }
-
 typedef unsigned long int size_t;
 
 #define offsetof(TYPE, MEMBER) ((size_t) &((TYPE *)0)->MEMBER)
@@ -47,3 +14,37 @@ int main(void) {
         offsetof(struct location, line);
         return 0;
 }
+
+// CHECK:hl.translation_unit {
+// CHECK:  hl.typedef "__int128_t" : !hl.int128
+// CHECK:  hl.typedef "__uint128_t" : !hl.int128< unsigned >
+// CHECK:  hl.struct "__NSConstantString_tag" {type_visibility = #unsup<attr "type_visibility">} : {
+// CHECK:    hl.field "isa" : !hl.ptr<!hl.int< const >>
+// CHECK:    hl.field "flags" : !hl.int
+// CHECK:    hl.field "str" : !hl.ptr<!hl.char< const >>
+// CHECK:    hl.field "length" : !hl.long
+// CHECK:  }
+// CHECK:  hl.typedef "__NSConstantString" : !hl.record<"__NSConstantString_tag">
+// CHECK:  hl.typedef "__builtin_ms_va_list" : !hl.ptr<!hl.char>
+// CHECK:  hl.struct "__va_list_tag" {type_visibility = #unsup<attr "type_visibility">} : {
+// CHECK:    hl.field "gp_offset" : !hl.int< unsigned >
+// CHECK:    hl.field "fp_offset" : !hl.int< unsigned >
+// CHECK:    hl.field "overflow_arg_area" : !hl.ptr<!hl.void>
+// CHECK:    hl.field "reg_save_area" : !hl.ptr<!hl.void>
+// CHECK:  }
+// CHECK:  hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
+// CHECK:  hl.typedef "size_t" : !hl.long< unsigned >
+// CHECK:  hl.struct "location" : {
+// CHECK:    hl.field "file" : !hl.ptr<!hl.char>
+// CHECK:    hl.field "line" : !hl.int
+// CHECK:    hl.field "col" : !hl.int
+// CHECK:  }
+// CHECK:  hl.func @main () -> !hl.int {
+// CHECK:    core.scope {
+// CHECK:      %0 = kernel.offsetof(!hl.elaborated<!hl.record<"location">>, "line") : () -> !hl.elaborated<!hl.typedef<"size_t">>
+// CHECK:      %1 = hl.const #core.integer<0> : !hl.int
+// CHECK:      hl.return %1 : !hl.int
+// CHECK:    }
+// CHECK:  }
+// CHECK:}
+

--- a/test/KernelTests/rcu_access_pointer.c
+++ b/test/KernelTests/rcu_access_pointer.c
@@ -1,43 +1,5 @@
 // RUN: kernelize -x c %s | FileCheck %s --match-full-lines
 
-// CHECK: hl.translation_unit {
-// CHECK:   hl.typedef "__int128_t" : !hl.int128
-// CHECK:   hl.typedef "__uint128_t" : !hl.int128< unsigned >
-// CHECK:   hl.struct "__NSConstantString_tag" : {
-// CHECK:     hl.field "isa" : !hl.ptr<!hl.int< const >>
-// CHECK:     hl.field "flags" : !hl.int
-// CHECK:     hl.field "str" : !hl.ptr<!hl.char< const >>
-// CHECK:     hl.field "length" : !hl.long
-// CHECK:   }
-// CHECK:   hl.typedef "__NSConstantString" : !hl.record<"__NSConstantString_tag">
-// CHECK:   hl.typedef "__builtin_ms_va_list" : !hl.ptr<!hl.char>
-// CHECK:   hl.struct "__va_list_tag" : {
-// CHECK:     hl.field "gp_offset" : !hl.int< unsigned >
-// CHECK:     hl.field "fp_offset" : !hl.int< unsigned >
-// CHECK:     hl.field "overflow_arg_area" : !hl.ptr<!hl.void>
-// CHECK:     hl.field "reg_save_area" : !hl.ptr<!hl.void>
-// CHECK:   }
-// CHECK:   hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
-// CHECK:   hl.func @main () -> !hl.int {
-// CHECK:     core.scope {
-// CHECK:       %0 = hl.var "p" : !hl.lvalue<!hl.ptr<!hl.int>> = {
-// CHECK:         %5 = hl.const #core.integer<12648430> : !hl.int
-// CHECK:         %6 = hl.cstyle_cast %5 IntegralToPointer : !hl.int -> !hl.ptr<!hl.void>
-// CHECK:         %7 = hl.implicit_cast %6 BitCast : !hl.ptr<!hl.void> -> !hl.ptr<!hl.int>
-// CHECK:         hl.value.yield %7 : !hl.ptr<!hl.int>
-// CHECK:       }
-// CHECK:       %1 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
-// CHECK:         %5 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:         hl.value.yield %5 : !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:       }
-// CHECK:       %2 = kernel.rcu_access_pointer rcu_access_pointer(%1) : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.int>
-// CHECK:       %3 = hl.implicit_cast %2 LValueToRValue : !hl.lvalue<!hl.int> -> !hl.int
-// CHECK:       %4 = hl.const #core.integer<0> : !hl.int
-// CHECK:       hl.return %4 : !hl.int
-// CHECK:     }
-// CHECK:   }
-// CHECK: }
-
 #define rcu_access_pointer(p) (*p)
 
 int main(void) {
@@ -45,3 +7,42 @@ int main(void) {
   rcu_access_pointer(p);
   return 0;
 }
+
+// CHECK:hl.translation_unit {
+// CHECK:  hl.typedef "__int128_t" : !hl.int128
+// CHECK:  hl.typedef "__uint128_t" : !hl.int128< unsigned >
+// CHECK:  hl.struct "__NSConstantString_tag" {type_visibility = #unsup<attr "type_visibility">} : {
+// CHECK:    hl.field "isa" : !hl.ptr<!hl.int< const >>
+// CHECK:    hl.field "flags" : !hl.int
+// CHECK:    hl.field "str" : !hl.ptr<!hl.char< const >>
+// CHECK:    hl.field "length" : !hl.long
+// CHECK:  }
+// CHECK:  hl.typedef "__NSConstantString" : !hl.record<"__NSConstantString_tag">
+// CHECK:  hl.typedef "__builtin_ms_va_list" : !hl.ptr<!hl.char>
+// CHECK:  hl.struct "__va_list_tag" {type_visibility = #unsup<attr "type_visibility">} : {
+// CHECK:    hl.field "gp_offset" : !hl.int< unsigned >
+// CHECK:    hl.field "fp_offset" : !hl.int< unsigned >
+// CHECK:    hl.field "overflow_arg_area" : !hl.ptr<!hl.void>
+// CHECK:    hl.field "reg_save_area" : !hl.ptr<!hl.void>
+// CHECK:  }
+// CHECK:  hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
+// CHECK:  hl.func @main () -> !hl.int {
+// CHECK:    core.scope {
+// CHECK:      %0 = hl.var "p" : !hl.lvalue<!hl.ptr<!hl.int>> = {
+// CHECK:        %5 = hl.const #core.integer<12648430> : !hl.int
+// CHECK:        %6 = hl.cstyle_cast %5 IntegralToPointer : !hl.int -> !hl.ptr<!hl.void>
+// CHECK:        %7 = hl.implicit_cast %6 BitCast : !hl.ptr<!hl.void> -> !hl.ptr<!hl.int>
+// CHECK:        hl.value.yield %7 : !hl.ptr<!hl.int>
+// CHECK:      }
+// CHECK:      %1 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:        %5 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:        hl.value.yield %5 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:      }
+// CHECK:      %2 = kernel.rcu_access_pointer(%1) : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.int>
+// CHECK:      %3 = hl.implicit_cast %2 LValueToRValue : !hl.lvalue<!hl.int> -> !hl.int
+// CHECK:      %4 = hl.const #core.integer<0> : !hl.int
+// CHECK:      hl.return %4 : !hl.int
+// CHECK:    }
+// CHECK:  }
+// CHECK:}
+

--- a/test/KernelTests/rcu_access_pointer.c
+++ b/test/KernelTests/rcu_access_pointer.c
@@ -1,0 +1,47 @@
+// RUN: kernelize -x c %s | FileCheck %s --match-full-lines
+
+// CHECK: hl.translation_unit {
+// CHECK:   hl.typedef "__int128_t" : !hl.int128
+// CHECK:   hl.typedef "__uint128_t" : !hl.int128< unsigned >
+// CHECK:   hl.struct "__NSConstantString_tag" : {
+// CHECK:     hl.field "isa" : !hl.ptr<!hl.int< const >>
+// CHECK:     hl.field "flags" : !hl.int
+// CHECK:     hl.field "str" : !hl.ptr<!hl.char< const >>
+// CHECK:     hl.field "length" : !hl.long
+// CHECK:   }
+// CHECK:   hl.typedef "__NSConstantString" : !hl.record<"__NSConstantString_tag">
+// CHECK:   hl.typedef "__builtin_ms_va_list" : !hl.ptr<!hl.char>
+// CHECK:   hl.struct "__va_list_tag" : {
+// CHECK:     hl.field "gp_offset" : !hl.int< unsigned >
+// CHECK:     hl.field "fp_offset" : !hl.int< unsigned >
+// CHECK:     hl.field "overflow_arg_area" : !hl.ptr<!hl.void>
+// CHECK:     hl.field "reg_save_area" : !hl.ptr<!hl.void>
+// CHECK:   }
+// CHECK:   hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
+// CHECK:   hl.func @main () -> !hl.int {
+// CHECK:     core.scope {
+// CHECK:       %0 = hl.var "p" : !hl.lvalue<!hl.ptr<!hl.int>> = {
+// CHECK:         %5 = hl.const #core.integer<12648430> : !hl.int
+// CHECK:         %6 = hl.cstyle_cast %5 IntegralToPointer : !hl.int -> !hl.ptr<!hl.void>
+// CHECK:         %7 = hl.implicit_cast %6 BitCast : !hl.ptr<!hl.void> -> !hl.ptr<!hl.int>
+// CHECK:         hl.value.yield %7 : !hl.ptr<!hl.int>
+// CHECK:       }
+// CHECK:       %1 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:         %5 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:         hl.value.yield %5 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:       }
+// CHECK:       %2 = kernel.rcu_access_pointer rcu_access_pointer(%1) : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.int>
+// CHECK:       %3 = hl.implicit_cast %2 LValueToRValue : !hl.lvalue<!hl.int> -> !hl.int
+// CHECK:       %4 = hl.const #core.integer<0> : !hl.int
+// CHECK:       hl.return %4 : !hl.int
+// CHECK:     }
+// CHECK:   }
+// CHECK: }
+
+#define rcu_access_pointer(p) (*p)
+
+int main(void) {
+  int *p = (void *)0xc0ffee;
+  rcu_access_pointer(p);
+  return 0;
+}

--- a/test/KernelTests/rcu_assign_pointer.c
+++ b/test/KernelTests/rcu_assign_pointer.c
@@ -1,42 +1,5 @@
 // RUN: kernelize -x c %s | FileCheck %s --match-full-lines
 
-// CHECK: hl.translation_unit {
-// CHECK:   hl.typedef "__int128_t" : !hl.int128
-// CHECK:   hl.typedef "__uint128_t" : !hl.int128< unsigned >
-// CHECK:   hl.struct "__NSConstantString_tag" : {
-// CHECK:     hl.field "isa" : !hl.ptr<!hl.int< const >>
-// CHECK:     hl.field "flags" : !hl.int
-// CHECK:     hl.field "str" : !hl.ptr<!hl.char< const >>
-// CHECK:     hl.field "length" : !hl.long
-// CHECK:   }
-// CHECK:   hl.typedef "__NSConstantString" : !hl.record<"__NSConstantString_tag">
-// CHECK:   hl.typedef "__builtin_ms_va_list" : !hl.ptr<!hl.char>
-// CHECK:   hl.struct "__va_list_tag" : {
-// CHECK:     hl.field "gp_offset" : !hl.int< unsigned >
-// CHECK:     hl.field "fp_offset" : !hl.int< unsigned >
-// CHECK:     hl.field "overflow_arg_area" : !hl.ptr<!hl.void>
-// CHECK:     hl.field "reg_save_area" : !hl.ptr<!hl.void>
-// CHECK:   }
-// CHECK:   hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
-// CHECK:   hl.func @main () -> !hl.int {
-// CHECK:     core.scope {
-// CHECK:       %0 = hl.var "p" : !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:       %1 = hl.var "v" : !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:       %2 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
-// CHECK:         %6 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:         hl.value.yield %6 : !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:       }
-// CHECK:       %3 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
-// CHECK:         %6 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:         hl.value.yield %6 : !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:       }
-// CHECK:       %4 = kernel.rcu_assign_pointer rcu_assign_pointer(%2, %3) : (!hl.lvalue<!hl.ptr<!hl.int>>, !hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.ptr<!hl.int>
-// CHECK:       %5 = hl.const #core.integer<0> : !hl.int
-// CHECK:       hl.return %5 : !hl.int
-// CHECK:     }
-// CHECK:   }
-// CHECK: }
-
 #define rcu_assign_pointer(p, v) ((p) = (v))
 
 int main(void) {
@@ -44,3 +7,41 @@ int main(void) {
   rcu_assign_pointer(p, v);
   return 0;
 }
+
+// CHECK:hl.translation_unit {
+// CHECK:  hl.typedef "__int128_t" : !hl.int128
+// CHECK:  hl.typedef "__uint128_t" : !hl.int128< unsigned >
+// CHECK:  hl.struct "__NSConstantString_tag" {type_visibility = #unsup<attr "type_visibility">} : {
+// CHECK:    hl.field "isa" : !hl.ptr<!hl.int< const >>
+// CHECK:    hl.field "flags" : !hl.int
+// CHECK:    hl.field "str" : !hl.ptr<!hl.char< const >>
+// CHECK:    hl.field "length" : !hl.long
+// CHECK:  }
+// CHECK:  hl.typedef "__NSConstantString" : !hl.record<"__NSConstantString_tag">
+// CHECK:  hl.typedef "__builtin_ms_va_list" : !hl.ptr<!hl.char>
+// CHECK:  hl.struct "__va_list_tag" {type_visibility = #unsup<attr "type_visibility">} : {
+// CHECK:    hl.field "gp_offset" : !hl.int< unsigned >
+// CHECK:    hl.field "fp_offset" : !hl.int< unsigned >
+// CHECK:    hl.field "overflow_arg_area" : !hl.ptr<!hl.void>
+// CHECK:    hl.field "reg_save_area" : !hl.ptr<!hl.void>
+// CHECK:  }
+// CHECK:  hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
+// CHECK:  hl.func @main () -> !hl.int {
+// CHECK:    core.scope {
+// CHECK:      %0 = hl.var "p" : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:      %1 = hl.var "v" : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:      %2 = macroni.parameter "v" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:        %6 = hl.ref %1 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:        hl.value.yield %6 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:      }
+// CHECK:      %3 = macroni.parameter "v" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:        %6 = hl.ref %1 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:        hl.value.yield %6 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:      }
+// CHECK:      %4 = kernel.rcu_assign_pointer(%2, %3) : (!hl.lvalue<!hl.ptr<!hl.int>>, !hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.ptr<!hl.int>
+// CHECK:      %5 = hl.const #core.integer<0> : !hl.int
+// CHECK:      hl.return %5 : !hl.int
+// CHECK:    }
+// CHECK:  }
+// CHECK:}
+

--- a/test/KernelTests/rcu_assign_pointer.c
+++ b/test/KernelTests/rcu_assign_pointer.c
@@ -1,0 +1,46 @@
+// RUN: kernelize -x c %s | FileCheck %s --match-full-lines
+
+// CHECK: hl.translation_unit {
+// CHECK:   hl.typedef "__int128_t" : !hl.int128
+// CHECK:   hl.typedef "__uint128_t" : !hl.int128< unsigned >
+// CHECK:   hl.struct "__NSConstantString_tag" : {
+// CHECK:     hl.field "isa" : !hl.ptr<!hl.int< const >>
+// CHECK:     hl.field "flags" : !hl.int
+// CHECK:     hl.field "str" : !hl.ptr<!hl.char< const >>
+// CHECK:     hl.field "length" : !hl.long
+// CHECK:   }
+// CHECK:   hl.typedef "__NSConstantString" : !hl.record<"__NSConstantString_tag">
+// CHECK:   hl.typedef "__builtin_ms_va_list" : !hl.ptr<!hl.char>
+// CHECK:   hl.struct "__va_list_tag" : {
+// CHECK:     hl.field "gp_offset" : !hl.int< unsigned >
+// CHECK:     hl.field "fp_offset" : !hl.int< unsigned >
+// CHECK:     hl.field "overflow_arg_area" : !hl.ptr<!hl.void>
+// CHECK:     hl.field "reg_save_area" : !hl.ptr<!hl.void>
+// CHECK:   }
+// CHECK:   hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
+// CHECK:   hl.func @main () -> !hl.int {
+// CHECK:     core.scope {
+// CHECK:       %0 = hl.var "p" : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:       %1 = hl.var "v" : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:       %2 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:         %6 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:         hl.value.yield %6 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:       }
+// CHECK:       %3 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:         %6 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:         hl.value.yield %6 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:       }
+// CHECK:       %4 = kernel.rcu_assign_pointer rcu_assign_pointer(%2, %3) : (!hl.lvalue<!hl.ptr<!hl.int>>, !hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.ptr<!hl.int>
+// CHECK:       %5 = hl.const #core.integer<0> : !hl.int
+// CHECK:       hl.return %5 : !hl.int
+// CHECK:     }
+// CHECK:   }
+// CHECK: }
+
+#define rcu_assign_pointer(p, v) ((p) = (v))
+
+int main(void) {
+  int *p, *v;
+  rcu_assign_pointer(p, v);
+  return 0;
+}

--- a/test/KernelTests/rcu_dereference.c
+++ b/test/KernelTests/rcu_dereference.c
@@ -21,50 +21,105 @@
 // CHECK:   hl.func @main () -> !hl.int {
 // CHECK:     core.scope {
 // CHECK:       %0 = hl.var "p" : !hl.lvalue<!hl.ptr<!hl.int>> = {
-// CHECK:         %4 = hl.const #core.integer<12648430> : !hl.int
-// CHECK:         %5 = hl.cstyle_cast %4 IntegralToPointer : !hl.int -> !hl.ptr<!hl.int>
-// CHECK:         hl.value.yield %5 : !hl.ptr<!hl.int>
+// CHECK:         %25 = hl.const #core.integer<12648430> : !hl.int
+// CHECK:         %26 = hl.cstyle_cast %25 IntegralToPointer : !hl.int -> !hl.ptr<!hl.int>
+// CHECK:         hl.value.yield %26 : !hl.ptr<!hl.int>
 // CHECK:       }
-// CHECK:       %1 = hl.var "x" : !hl.lvalue<!hl.int> = {
-// CHECK:         %4 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
-// CHECK:           %7 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:           hl.value.yield %7 : !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:         }
-// CHECK:         %5 = kernel.rcu_dereference rcu_dereference(%4) : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.int>
-// CHECK:         %6 = hl.implicit_cast %5 LValueToRValue : !hl.lvalue<!hl.int> -> !hl.int
-// CHECK:         hl.value.yield %6 : !hl.int
+// CHECK:       %1 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:         %25 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:         hl.value.yield %25 : !hl.lvalue<!hl.ptr<!hl.int>>
 // CHECK:       }
-// CHECK:       %2 = hl.var "y" : !hl.lvalue<!hl.int> = {
-// CHECK:         %4 = macroni.expansion "deref(p)" : !hl.lvalue<!hl.int> {
-// CHECK:           %6 = hl.expr : !hl.lvalue<!hl.int> {
-// CHECK:             %7 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
-// CHECK:               %9 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
-// CHECK:                 %10 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:                 hl.value.yield %10 : !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:               }
-// CHECK:               hl.value.yield %9 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:       %2 = kernel.rcu_dereference rcu_dereference(%1) : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.int>
+// CHECK:       %3 = hl.implicit_cast %2 LValueToRValue : !hl.lvalue<!hl.int> -> !hl.int
+// CHECK:       %4 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:         %25 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:         hl.value.yield %25 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:       }
+// CHECK:       %5 = kernel.rcu_dereference_bh rcu_dereference_bh(%4) : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.int>
+// CHECK:       %6 = hl.implicit_cast %5 LValueToRValue : !hl.lvalue<!hl.int> -> !hl.int
+// CHECK:       %7 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:         %25 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:         hl.value.yield %25 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:       }
+// CHECK:       %8 = kernel.rcu_dereference_sched rcu_dereference_sched(%7) : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.int>
+// CHECK:       %9 = hl.implicit_cast %8 LValueToRValue : !hl.lvalue<!hl.int> -> !hl.int
+// CHECK:       %10 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:         %25 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:         hl.value.yield %25 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:       }
+// CHECK:       %11 = macroni.parameter "c" : !hl.int {
+// CHECK:         %25 = hl.const #core.integer<1> : !hl.int
+// CHECK:         hl.value.yield %25 : !hl.int
+// CHECK:       }
+// CHECK:       %12 = kernel.rcu_dereference_check rcu_dereference_check(%10, %11) : (!hl.lvalue<!hl.ptr<!hl.int>>, !hl.int) -> !hl.int
+// CHECK:       %13 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:         %25 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:         hl.value.yield %25 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:       }
+// CHECK:       %14 = macroni.parameter "c" : !hl.int {
+// CHECK:         %25 = hl.const #core.integer<1> : !hl.int
+// CHECK:         hl.value.yield %25 : !hl.int
+// CHECK:       }
+// CHECK:       %15 = kernel.rcu_dereference_bh_check rcu_dereference_bh_check(%13, %14) : (!hl.lvalue<!hl.ptr<!hl.int>>, !hl.int) -> !hl.int
+// CHECK:       %16 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:         %25 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:         hl.value.yield %25 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:       }
+// CHECK:       %17 = macroni.parameter "c" : !hl.int {
+// CHECK:         %25 = hl.const #core.integer<1> : !hl.int
+// CHECK:         hl.value.yield %25 : !hl.int
+// CHECK:       }
+// CHECK:       %18 = kernel.rcu_dereference_sched_check rcu_dereference_sched_check(%16, %17) : (!hl.lvalue<!hl.ptr<!hl.int>>, !hl.int) -> !hl.int
+// CHECK:       %19 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:         %25 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:         hl.value.yield %25 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:       }
+// CHECK:       %20 = macroni.parameter "c" : !hl.int {
+// CHECK:         %25 = hl.const #core.integer<1> : !hl.int
+// CHECK:         hl.value.yield %25 : !hl.int
+// CHECK:       }
+// CHECK:       %21 = kernel.rcu_dereference_protected rcu_dereference_protected(%19, %20) : (!hl.lvalue<!hl.ptr<!hl.int>>, !hl.int) -> !hl.int
+// CHECK:       %22 = macroni.expansion "deref(p)" : !hl.lvalue<!hl.int> {
+// CHECK:         %25 = hl.expr : !hl.lvalue<!hl.int> {
+// CHECK:           %26 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:             %28 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:               %29 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:               hl.value.yield %29 : !hl.lvalue<!hl.ptr<!hl.int>>
 // CHECK:             }
-// CHECK:             %8 = kernel.rcu_dereference rcu_dereference(%7) : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.int>
-// CHECK:             hl.value.yield %8 : !hl.lvalue<!hl.int>
+// CHECK:             hl.value.yield %28 : !hl.lvalue<!hl.ptr<!hl.int>>
 // CHECK:           }
-// CHECK:           hl.value.yield %6 : !hl.lvalue<!hl.int>
+// CHECK:           %27 = kernel.rcu_dereference rcu_dereference(%26) : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.int>
+// CHECK:           hl.value.yield %27 : !hl.lvalue<!hl.int>
 // CHECK:         }
-// CHECK:         %5 = hl.implicit_cast %4 LValueToRValue : !hl.lvalue<!hl.int> -> !hl.int
-// CHECK:         hl.value.yield %5 : !hl.int
+// CHECK:         hl.value.yield %25 : !hl.lvalue<!hl.int>
 // CHECK:       }
-// CHECK:       %3 = hl.const #core.integer<0> : !hl.int
-// CHECK:       hl.return %3 : !hl.int
+// CHECK:       %23 = hl.implicit_cast %22 LValueToRValue : !hl.lvalue<!hl.int> -> !hl.int
+// CHECK:       %24 = hl.const #core.integer<0> : !hl.int
+// CHECK:       hl.return %24 : !hl.int
 // CHECK:     }
 // CHECK:   }
 // CHECK: }
 
+
 #define rcu_dereference(p) (*p)
+#define rcu_dereference_bh(p) (*p)
+#define rcu_dereference_sched(p) (*p)
+#define rcu_dereference_check(p, c) (c && *p)
+#define rcu_dereference_bh_check(p, c) (c && *p)
+#define rcu_dereference_sched_check(p, c) (c && *p)
+#define rcu_dereference_protected(p, c) (c && *p)
 
 #define deref(p) (rcu_dereference(p))
 
 int main(void) {
-        int *p = (int *) 0xC0FFEE,
-                x = rcu_dereference(p),
-                y = deref(p);
+        int *p = (int *) 0xC0FFEE;
+        rcu_dereference(p);
+        rcu_dereference_bh(p);
+        rcu_dereference_sched(p);
+        rcu_dereference_check(p, 1);
+        rcu_dereference_bh_check(p, 1);
+        rcu_dereference_sched_check(p, 1);
+        rcu_dereference_protected(p, 1);
+        deref(p);
         return 0;
 }

--- a/test/KernelTests/rcu_dereference.c
+++ b/test/KernelTests/rcu_dereference.c
@@ -1,106 +1,5 @@
 // RUN: kernelize -x c %s | FileCheck %s --match-full-lines
 
-// CHECK: hl.translation_unit {
-// CHECK:   hl.typedef "__int128_t" : !hl.int128
-// CHECK:   hl.typedef "__uint128_t" : !hl.int128< unsigned >
-// CHECK:   hl.struct "__NSConstantString_tag" : {
-// CHECK:     hl.field "isa" : !hl.ptr<!hl.int< const >>
-// CHECK:     hl.field "flags" : !hl.int
-// CHECK:     hl.field "str" : !hl.ptr<!hl.char< const >>
-// CHECK:     hl.field "length" : !hl.long
-// CHECK:   }
-// CHECK:   hl.typedef "__NSConstantString" : !hl.record<"__NSConstantString_tag">
-// CHECK:   hl.typedef "__builtin_ms_va_list" : !hl.ptr<!hl.char>
-// CHECK:   hl.struct "__va_list_tag" : {
-// CHECK:     hl.field "gp_offset" : !hl.int< unsigned >
-// CHECK:     hl.field "fp_offset" : !hl.int< unsigned >
-// CHECK:     hl.field "overflow_arg_area" : !hl.ptr<!hl.void>
-// CHECK:     hl.field "reg_save_area" : !hl.ptr<!hl.void>
-// CHECK:   }
-// CHECK:   hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
-// CHECK:   hl.func @main () -> !hl.int {
-// CHECK:     core.scope {
-// CHECK:       %0 = hl.var "p" : !hl.lvalue<!hl.ptr<!hl.int>> = {
-// CHECK:         %25 = hl.const #core.integer<12648430> : !hl.int
-// CHECK:         %26 = hl.cstyle_cast %25 IntegralToPointer : !hl.int -> !hl.ptr<!hl.int>
-// CHECK:         hl.value.yield %26 : !hl.ptr<!hl.int>
-// CHECK:       }
-// CHECK:       %1 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
-// CHECK:         %25 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:         hl.value.yield %25 : !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:       }
-// CHECK:       %2 = kernel.rcu_dereference rcu_dereference(%1) : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.int>
-// CHECK:       %3 = hl.implicit_cast %2 LValueToRValue : !hl.lvalue<!hl.int> -> !hl.int
-// CHECK:       %4 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
-// CHECK:         %25 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:         hl.value.yield %25 : !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:       }
-// CHECK:       %5 = kernel.rcu_dereference_bh rcu_dereference_bh(%4) : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.int>
-// CHECK:       %6 = hl.implicit_cast %5 LValueToRValue : !hl.lvalue<!hl.int> -> !hl.int
-// CHECK:       %7 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
-// CHECK:         %25 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:         hl.value.yield %25 : !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:       }
-// CHECK:       %8 = kernel.rcu_dereference_sched rcu_dereference_sched(%7) : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.int>
-// CHECK:       %9 = hl.implicit_cast %8 LValueToRValue : !hl.lvalue<!hl.int> -> !hl.int
-// CHECK:       %10 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
-// CHECK:         %25 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:         hl.value.yield %25 : !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:       }
-// CHECK:       %11 = macroni.parameter "c" : !hl.int {
-// CHECK:         %25 = hl.const #core.integer<1> : !hl.int
-// CHECK:         hl.value.yield %25 : !hl.int
-// CHECK:       }
-// CHECK:       %12 = kernel.rcu_dereference_check rcu_dereference_check(%10, %11) : (!hl.lvalue<!hl.ptr<!hl.int>>, !hl.int) -> !hl.int
-// CHECK:       %13 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
-// CHECK:         %25 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:         hl.value.yield %25 : !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:       }
-// CHECK:       %14 = macroni.parameter "c" : !hl.int {
-// CHECK:         %25 = hl.const #core.integer<1> : !hl.int
-// CHECK:         hl.value.yield %25 : !hl.int
-// CHECK:       }
-// CHECK:       %15 = kernel.rcu_dereference_bh_check rcu_dereference_bh_check(%13, %14) : (!hl.lvalue<!hl.ptr<!hl.int>>, !hl.int) -> !hl.int
-// CHECK:       %16 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
-// CHECK:         %25 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:         hl.value.yield %25 : !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:       }
-// CHECK:       %17 = macroni.parameter "c" : !hl.int {
-// CHECK:         %25 = hl.const #core.integer<1> : !hl.int
-// CHECK:         hl.value.yield %25 : !hl.int
-// CHECK:       }
-// CHECK:       %18 = kernel.rcu_dereference_sched_check rcu_dereference_sched_check(%16, %17) : (!hl.lvalue<!hl.ptr<!hl.int>>, !hl.int) -> !hl.int
-// CHECK:       %19 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
-// CHECK:         %25 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:         hl.value.yield %25 : !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:       }
-// CHECK:       %20 = macroni.parameter "c" : !hl.int {
-// CHECK:         %25 = hl.const #core.integer<1> : !hl.int
-// CHECK:         hl.value.yield %25 : !hl.int
-// CHECK:       }
-// CHECK:       %21 = kernel.rcu_dereference_protected rcu_dereference_protected(%19, %20) : (!hl.lvalue<!hl.ptr<!hl.int>>, !hl.int) -> !hl.int
-// CHECK:       %22 = macroni.expansion "deref(p)" : !hl.lvalue<!hl.int> {
-// CHECK:         %25 = hl.expr : !hl.lvalue<!hl.int> {
-// CHECK:           %26 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
-// CHECK:             %28 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
-// CHECK:               %29 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:               hl.value.yield %29 : !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:             }
-// CHECK:             hl.value.yield %28 : !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:           }
-// CHECK:           %27 = kernel.rcu_dereference rcu_dereference(%26) : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.int>
-// CHECK:           hl.value.yield %27 : !hl.lvalue<!hl.int>
-// CHECK:         }
-// CHECK:         hl.value.yield %25 : !hl.lvalue<!hl.int>
-// CHECK:       }
-// CHECK:       %23 = hl.implicit_cast %22 LValueToRValue : !hl.lvalue<!hl.int> -> !hl.int
-// CHECK:       %24 = hl.const #core.integer<0> : !hl.int
-// CHECK:       hl.return %24 : !hl.int
-// CHECK:     }
-// CHECK:   }
-// CHECK: }
-
-
 #define rcu_dereference(p) (*p)
 #define rcu_dereference_bh(p) (*p)
 #define rcu_dereference_sched(p) (*p)
@@ -123,3 +22,104 @@ int main(void) {
         deref(p);
         return 0;
 }
+
+// CHECK:hl.translation_unit {
+// CHECK:  hl.typedef "__int128_t" : !hl.int128
+// CHECK:  hl.typedef "__uint128_t" : !hl.int128< unsigned >
+// CHECK:  hl.struct "__NSConstantString_tag" {type_visibility = #unsup<attr "type_visibility">} : {
+// CHECK:    hl.field "isa" : !hl.ptr<!hl.int< const >>
+// CHECK:    hl.field "flags" : !hl.int
+// CHECK:    hl.field "str" : !hl.ptr<!hl.char< const >>
+// CHECK:    hl.field "length" : !hl.long
+// CHECK:  }
+// CHECK:  hl.typedef "__NSConstantString" : !hl.record<"__NSConstantString_tag">
+// CHECK:  hl.typedef "__builtin_ms_va_list" : !hl.ptr<!hl.char>
+// CHECK:  hl.struct "__va_list_tag" {type_visibility = #unsup<attr "type_visibility">} : {
+// CHECK:    hl.field "gp_offset" : !hl.int< unsigned >
+// CHECK:    hl.field "fp_offset" : !hl.int< unsigned >
+// CHECK:    hl.field "overflow_arg_area" : !hl.ptr<!hl.void>
+// CHECK:    hl.field "reg_save_area" : !hl.ptr<!hl.void>
+// CHECK:  }
+// CHECK:  hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
+// CHECK:  hl.func @main () -> !hl.int {
+// CHECK:    core.scope {
+// CHECK:      %0 = hl.var "p" : !hl.lvalue<!hl.ptr<!hl.int>> = {
+// CHECK:        %25 = hl.const #core.integer<12648430> : !hl.int
+// CHECK:        %26 = hl.cstyle_cast %25 IntegralToPointer : !hl.int -> !hl.ptr<!hl.int>
+// CHECK:        hl.value.yield %26 : !hl.ptr<!hl.int>
+// CHECK:      }
+// CHECK:      %1 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:        %25 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:        hl.value.yield %25 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:      }
+// CHECK:      %2 = kernel.rcu_dereference(%1) : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.int>
+// CHECK:      %3 = hl.implicit_cast %2 LValueToRValue : !hl.lvalue<!hl.int> -> !hl.int
+// CHECK:      %4 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:        %25 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:        hl.value.yield %25 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:      }
+// CHECK:      %5 = kernel.rcu_dereference_bh(%4) : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.int>
+// CHECK:      %6 = hl.implicit_cast %5 LValueToRValue : !hl.lvalue<!hl.int> -> !hl.int
+// CHECK:      %7 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:        %25 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:        hl.value.yield %25 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:      }
+// CHECK:      %8 = kernel.rcu_dereference_sched(%7) : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.int>
+// CHECK:      %9 = hl.implicit_cast %8 LValueToRValue : !hl.lvalue<!hl.int> -> !hl.int
+// CHECK:      %10 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:        %25 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:        hl.value.yield %25 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:      }
+// CHECK:      %11 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:        %25 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:        hl.value.yield %25 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:      }
+// CHECK:      %12 = kernel.rcu_dereference_check(%10, %11) : (!hl.lvalue<!hl.ptr<!hl.int>>, !hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.int
+// CHECK:      %13 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:        %25 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:        hl.value.yield %25 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:      }
+// CHECK:      %14 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:        %25 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:        hl.value.yield %25 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:      }
+// CHECK:      %15 = kernel.rcu_dereference_bh_check(%13, %14) : (!hl.lvalue<!hl.ptr<!hl.int>>, !hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.int
+// CHECK:      %16 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:        %25 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:        hl.value.yield %25 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:      }
+// CHECK:      %17 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:        %25 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:        hl.value.yield %25 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:      }
+// CHECK:      %18 = kernel.rcu_dereference_sched_check(%16, %17) : (!hl.lvalue<!hl.ptr<!hl.int>>, !hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.int
+// CHECK:      %19 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:        %25 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:        hl.value.yield %25 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:      }
+// CHECK:      %20 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:        %25 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:        hl.value.yield %25 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:      }
+// CHECK:      %21 = kernel.rcu_dereference_protected(%19, %20) : (!hl.lvalue<!hl.ptr<!hl.int>>, !hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.int
+// CHECK:      %22 = macroni.expansion "deref(p)" : !hl.lvalue<!hl.int> {
+// CHECK:        %25 = hl.expr : !hl.lvalue<!hl.int> {
+// CHECK:          %26 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:            %28 = macroni.parameter "p" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:              %29 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:              hl.value.yield %29 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:            }
+// CHECK:            hl.value.yield %28 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:          }
+// CHECK:          %27 = kernel.rcu_dereference(%26) : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.int>
+// CHECK:          hl.value.yield %27 : !hl.lvalue<!hl.int>
+// CHECK:        }
+// CHECK:        hl.value.yield %25 : !hl.lvalue<!hl.int>
+// CHECK:      }
+// CHECK:      %23 = hl.implicit_cast %22 LValueToRValue : !hl.lvalue<!hl.int> -> !hl.int
+// CHECK:      %24 = hl.const #core.integer<0> : !hl.int
+// CHECK:      hl.return %24 : !hl.int
+// CHECK:    }
+// CHECK:  }
+// CHECK:}
+

--- a/test/KernelTests/rcu_dereference_warnings.c
+++ b/test/KernelTests/rcu_dereference_warnings.c
@@ -1,0 +1,48 @@
+// RUN: kernelize -x c %s 2>&1 1>/dev/null | FileCheck %s
+
+// CHECK: warning: Invocation of rcu_dereference() outside of RCU critical section
+// CHECK: warning: Invocation of rcu_dereference_bh() outside of RCU critical section
+// CHECK: warning: Invocation of rcu_dereference_sched() outside of RCU critical section
+// CHECK: warning: Invocation of rcu_dereference_check() outside of RCU critical section
+// CHECK: warning: Invocation of rcu_dereference_bh_check() outside of RCU critical section
+// CHECK: warning: Invocation of rcu_dereference_sched_check() outside of RCU critical section
+// CHECK: warning: Invocation of rcu_dereference_protected() outside of RCU critical section
+// CHECK: warning: Invocation of rcu_dereference() outside of RCU critical section
+
+#define rcu_dereference(p) (*p)
+#define rcu_dereference_bh(p) (*p)
+#define rcu_dereference_sched(p) (*p)
+#define rcu_dereference_check(p, c) (c && *p)
+#define rcu_dereference_bh_check(p, c) (c && *p)
+#define rcu_dereference_sched_check(p, c) (c && *p)
+#define rcu_dereference_protected(p, c) (c && *p)
+
+#define deref(p) (rcu_dereference(p))
+
+void rcu_read_lock(void) {}
+void rcu_read_unlock(void) {}
+
+int main(void) {
+        int *p = (int *) 0xC0FFEE;
+
+        rcu_dereference(p);
+        rcu_dereference_bh(p);
+        rcu_dereference_sched(p);
+        rcu_dereference_check(p, 1);
+        rcu_dereference_bh_check(p, 1);
+        rcu_dereference_sched_check(p, 1);
+        rcu_dereference_protected(p, 1);
+        deref(p);
+
+        rcu_read_lock();
+        rcu_dereference(p);
+        rcu_dereference_bh(p);
+        rcu_dereference_sched(p);
+        rcu_dereference_check(p, 1);
+        rcu_dereference_bh_check(p, 1);
+        rcu_dereference_sched_check(p, 1);
+        rcu_dereference_protected(p, 1);
+        deref(p);
+        rcu_read_unlock();
+        return 0;
+}

--- a/test/KernelTests/rcu_dereference_warnings.c
+++ b/test/KernelTests/rcu_dereference_warnings.c
@@ -7,7 +7,9 @@
 // CHECK: warning: Invocation of rcu_dereference_bh_check() outside of RCU critical section
 // CHECK: warning: Invocation of rcu_dereference_sched_check() outside of RCU critical section
 // CHECK: warning: Invocation of rcu_dereference_protected() outside of RCU critical section
+// CHECK: warning: Invocation of rcu_access_pointer() outside of RCU critical section
 // CHECK: warning: Invocation of rcu_dereference() outside of RCU critical section
+// CHECK: suggestion: Use rcu_dereference_protected() instead of rcu_access_pointer()
 
 #define rcu_dereference(p) (*p)
 #define rcu_dereference_bh(p) (*p)
@@ -16,6 +18,7 @@
 #define rcu_dereference_bh_check(p, c) (c && *p)
 #define rcu_dereference_sched_check(p, c) (c && *p)
 #define rcu_dereference_protected(p, c) (c && *p)
+#define rcu_access_pointer(p) (*p)
 
 #define deref(p) (rcu_dereference(p))
 
@@ -32,6 +35,7 @@ int main(void) {
         rcu_dereference_bh_check(p, 1);
         rcu_dereference_sched_check(p, 1);
         rcu_dereference_protected(p, 1);
+        rcu_access_pointer(p);
         deref(p);
 
         rcu_read_lock();
@@ -43,6 +47,8 @@ int main(void) {
         rcu_dereference_sched_check(p, 1);
         rcu_dereference_protected(p, 1);
         deref(p);
+        rcu_access_pointer(p);
         rcu_read_unlock();
+
         return 0;
 }

--- a/test/KernelTests/rcu_read_lock_unlock.c
+++ b/test/KernelTests/rcu_read_lock_unlock.c
@@ -51,30 +51,32 @@
 // CHECK:     }
 // CHECK:   }
 // CHECK:   hl.func @main () -> !hl.int {
+// CHECK:     %0 = hl.label.decl "a_label" : !hl.label
+// CHECK:     %1 = hl.label.decl "b_label" : !hl.label
 // CHECK:     core.scope {
-// CHECK:       %0 = hl.var "i" : !hl.lvalue<!hl.int>
+// CHECK:       %3 = hl.var "i" : !hl.lvalue<!hl.int>
 // CHECK:       kernel.rcu.critical_section {
 // CHECK:       }
 // CHECK:       kernel.rcu.critical_section {
-// CHECK:         %2 = hl.call @foo() : () -> !hl.void
+// CHECK:         %5 = hl.call @foo() : () -> !hl.void
 // CHECK:       }
 // CHECK:       kernel.rcu.critical_section {
 // CHECK:         core.scope {
-// CHECK:           %2 = hl.ref %0 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
-// CHECK:           %3 = hl.const #core.integer<0> : !hl.int
-// CHECK:           %4 = hl.assign %3 to %2 : !hl.int, !hl.lvalue<!hl.int> -> !hl.int
+// CHECK:           %5 = hl.ref %3 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
+// CHECK:           %6 = hl.const #core.integer<0> : !hl.int
+// CHECK:           %7 = hl.assign %6 to %5 : !hl.int, !hl.lvalue<!hl.int> -> !hl.int
 // CHECK:           hl.for {
-// CHECK:             %5 = hl.ref %0 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
-// CHECK:             %6 = hl.implicit_cast %5 LValueToRValue : !hl.lvalue<!hl.int> -> !hl.int
-// CHECK:             %7 = hl.const #core.integer<10> : !hl.int
-// CHECK:             %8 = hl.cmp slt %6, %7 : !hl.int, !hl.int -> !hl.int
-// CHECK:             hl.cond.yield %8 : !hl.int
+// CHECK:             %8 = hl.ref %3 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
+// CHECK:             %9 = hl.implicit_cast %8 LValueToRValue : !hl.lvalue<!hl.int> -> !hl.int
+// CHECK:             %10 = hl.const #core.integer<10> : !hl.int
+// CHECK:             %11 = hl.cmp slt %9, %10 : !hl.int, !hl.int -> !hl.int
+// CHECK:             hl.cond.yield %11 : !hl.int
 // CHECK:           } incr {
-// CHECK:             %5 = hl.ref %0 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
-// CHECK:             %6 = hl.post.inc %5 : !hl.lvalue<!hl.int> -> !hl.int
+// CHECK:             %8 = hl.ref %3 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
+// CHECK:             %9 = hl.post.inc %8 : !hl.lvalue<!hl.int> -> !hl.int
 // CHECK:           } do {
 // CHECK:             core.scope {
-// CHECK:               %5 = hl.call @foo() : () -> !hl.void
+// CHECK:               %8 = hl.call @foo() : () -> !hl.void
 // CHECK:             }
 // CHECK:           }
 // CHECK:         }
@@ -88,11 +90,11 @@
 // CHECK:       kernel.rcu.critical_section {
 // CHECK:         hl.do {
 // CHECK:           core.scope {
-// CHECK:             %2 = hl.var "x" : !hl.lvalue<!hl.int>
+// CHECK:             %5 = hl.var "x" : !hl.lvalue<!hl.int>
 // CHECK:           }
 // CHECK:         } while {
-// CHECK:           %2 = hl.const #core.integer<0> : !hl.int
-// CHECK:           hl.cond.yield %2 : !hl.int
+// CHECK:           %5 = hl.const #core.integer<0> : !hl.int
+// CHECK:           hl.cond.yield %5 : !hl.int
 // CHECK:         }
 // CHECK:       }
 // CHECK:       kernel.rcu.critical_section {
@@ -107,50 +109,61 @@
 // CHECK:         hl.do {
 // CHECK:           core.scope {
 // CHECK:             kernel.rcu.critical_section {
-// CHECK:               %2 = hl.var "x" : !hl.lvalue<!hl.int>
+// CHECK:               %5 = hl.var "x" : !hl.lvalue<!hl.int>
 // CHECK:             }
 // CHECK:           }
 // CHECK:         } while {
-// CHECK:           %2 = hl.const #core.integer<0> : !hl.int
-// CHECK:           hl.cond.yield %2 : !hl.int
+// CHECK:           %5 = hl.const #core.integer<0> : !hl.int
+// CHECK:           hl.cond.yield %5 : !hl.int
 // CHECK:         }
 // CHECK:       }
 // CHECK:       hl.do {
 // CHECK:         core.scope {
 // CHECK:           kernel.rcu.critical_section {
-// CHECK:             %2 = hl.var "x" : !hl.lvalue<!hl.int> = {
-// CHECK:               %4 = hl.const #core.integer<1> : !hl.int
-// CHECK:               hl.value.yield %4 : !hl.int
+// CHECK:             %5 = hl.var "x" : !hl.lvalue<!hl.int> = {
+// CHECK:               %7 = hl.const #core.integer<1> : !hl.int
+// CHECK:               hl.value.yield %7 : !hl.int
 // CHECK:             }
 // CHECK:             kernel.rcu.critical_section {
 // CHECK:             }
-// CHECK:             %3 = hl.var "y" : !hl.lvalue<!hl.int> = {
-// CHECK:               %4 = hl.const #core.integer<2> : !hl.int
-// CHECK:               hl.value.yield %4 : !hl.int
+// CHECK:             %6 = hl.var "y" : !hl.lvalue<!hl.int> = {
+// CHECK:               %7 = hl.const #core.integer<2> : !hl.int
+// CHECK:               hl.value.yield %7 : !hl.int
 // CHECK:             }
 // CHECK:           }
 // CHECK:         }
 // CHECK:       } while {
-// CHECK:         %2 = hl.const #core.integer<0> : !hl.int
-// CHECK:         hl.cond.yield %2 : !hl.int
+// CHECK:         %5 = hl.const #core.integer<0> : !hl.int
+// CHECK:         hl.cond.yield %5 : !hl.int
 // CHECK:       }
 // CHECK:       kernel.rcu.critical_section {
 // CHECK:         hl.if {
-// CHECK:           %2 = hl.const #core.integer<1> : !hl.int
-// CHECK:           hl.cond.yield %2 : !hl.int
+// CHECK:           %5 = hl.const #core.integer<1> : !hl.int
+// CHECK:           hl.cond.yield %5 : !hl.int
 // CHECK:         } then {
 // CHECK:           core.scope {
-// CHECK:             %2 = hl.call @rcu_read_unlock() {lock_level = 0 : i64} : () -> !hl.void
+// CHECK:             %5 = hl.call @rcu_read_unlock() {lock_level = 0 : i64} : () -> !hl.void
 // CHECK:           }
 // CHECK:         } else {
 // CHECK:           core.scope {
-// CHECK:             %2 = hl.call @rcu_read_lock() {lock_level = 0 : i64} : () -> !hl.void
+// CHECK:             %5 = hl.call @rcu_read_lock() {lock_level = 0 : i64} : () -> !hl.void
 // CHECK:           }
 // CHECK:         }
 // CHECK:       }
-// CHECK:       %1 = hl.const #core.integer<0> : !hl.int
-// CHECK:       hl.return %1 : !hl.int
+// CHECK:       kernel.rcu.critical_section {
+// CHECK:       }
+// CHECK:       hl.label %0 {
+// CHECK:       }
+// CHECK:       kernel.rcu.critical_section {
+// CHECK:         %5 = hl.const #core.integer<1> : !hl.int
+// CHECK:       }
+// CHECK:       hl.label %1 {
+// CHECK:       }
+// CHECK:       %4 = hl.const #core.integer<0> : !hl.int
+// CHECK:       hl.return %4 : !hl.int
 // CHECK:     }
+// CHECK:     %2 = hl.const #core.integer<0> : !hl.int
+// CHECK:     hl.return %2 : !hl.int
 // CHECK:   }
 // CHECK: }
 
@@ -229,6 +242,15 @@ int main(void) {
         } else {
                 rcu_read_lock();
         }
+        rcu_read_unlock();
+
+        rcu_read_lock();
+a_label:
+        rcu_read_unlock();
+
+        rcu_read_lock();
+        1;
+b_label:
         rcu_read_unlock();
 
         return 0;

--- a/test/KernelTests/rcu_read_lock_unlock.c
+++ b/test/KernelTests/rcu_read_lock_unlock.c
@@ -1,172 +1,5 @@
 // RUN: kernelize -x c %s | FileCheck %s --match-full-lines
 
-// CHECK: hl.translation_unit {
-// CHECK:   hl.typedef "__int128_t" : !hl.int128
-// CHECK:   hl.typedef "__uint128_t" : !hl.int128< unsigned >
-// CHECK:   hl.struct "__NSConstantString_tag" : {
-// CHECK:     hl.field "isa" : !hl.ptr<!hl.int< const >>
-// CHECK:     hl.field "flags" : !hl.int
-// CHECK:     hl.field "str" : !hl.ptr<!hl.char< const >>
-// CHECK:     hl.field "length" : !hl.long
-// CHECK:   }
-// CHECK:   hl.typedef "__NSConstantString" : !hl.record<"__NSConstantString_tag">
-// CHECK:   hl.typedef "__builtin_ms_va_list" : !hl.ptr<!hl.char>
-// CHECK:   hl.struct "__va_list_tag" : {
-// CHECK:     hl.field "gp_offset" : !hl.int< unsigned >
-// CHECK:     hl.field "fp_offset" : !hl.int< unsigned >
-// CHECK:     hl.field "overflow_arg_area" : !hl.ptr<!hl.void>
-// CHECK:     hl.field "reg_save_area" : !hl.ptr<!hl.void>
-// CHECK:   }
-// CHECK:   hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
-// CHECK:   hl.func @rcu_read_lock () -> !hl.void {
-// CHECK:     core.scope {
-// CHECK:       %0 = hl.const #void_value
-// CHECK:       core.implicit.return %0 : !hl.void
-// CHECK:     }
-// CHECK:   }
-// CHECK:   hl.func @rcu_read_unlock () -> !hl.void {
-// CHECK:     core.scope {
-// CHECK:       %0 = hl.const #void_value
-// CHECK:       core.implicit.return %0 : !hl.void
-// CHECK:     }
-// CHECK:   }
-// CHECK:   hl.func @lock () -> !hl.void {
-// CHECK:     core.scope {
-// CHECK:       %0 = hl.call @rcu_read_lock() {lock_level = 0 : i64} : () -> !hl.void
-// CHECK:       %1 = hl.const #void_value
-// CHECK:       core.implicit.return %1 : !hl.void
-// CHECK:     }
-// CHECK:   }
-// CHECK:   hl.func @unlock () -> !hl.void {
-// CHECK:     core.scope {
-// CHECK:       %0 = hl.call @rcu_read_unlock() {lock_level = 0 : i64} : () -> !hl.void
-// CHECK:       %1 = hl.const #void_value
-// CHECK:       core.implicit.return %1 : !hl.void
-// CHECK:     }
-// CHECK:   }
-// CHECK:   hl.func @foo () -> !hl.void {
-// CHECK:     core.scope {
-// CHECK:       %0 = hl.const #void_value
-// CHECK:       core.implicit.return %0 : !hl.void
-// CHECK:     }
-// CHECK:   }
-// CHECK:   hl.func @main () -> !hl.int {
-// CHECK:     %0 = hl.label.decl "a_label" : !hl.label
-// CHECK:     %1 = hl.label.decl "b_label" : !hl.label
-// CHECK:     core.scope {
-// CHECK:       %3 = hl.var "i" : !hl.lvalue<!hl.int>
-// CHECK:       kernel.rcu.critical_section {
-// CHECK:       }
-// CHECK:       kernel.rcu.critical_section {
-// CHECK:         %5 = hl.call @foo() : () -> !hl.void
-// CHECK:       }
-// CHECK:       kernel.rcu.critical_section {
-// CHECK:         core.scope {
-// CHECK:           %5 = hl.ref %3 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
-// CHECK:           %6 = hl.const #core.integer<0> : !hl.int
-// CHECK:           %7 = hl.assign %6 to %5 : !hl.int, !hl.lvalue<!hl.int> -> !hl.int
-// CHECK:           hl.for {
-// CHECK:             %8 = hl.ref %3 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
-// CHECK:             %9 = hl.implicit_cast %8 LValueToRValue : !hl.lvalue<!hl.int> -> !hl.int
-// CHECK:             %10 = hl.const #core.integer<10> : !hl.int
-// CHECK:             %11 = hl.cmp slt %9, %10 : !hl.int, !hl.int -> !hl.int
-// CHECK:             hl.cond.yield %11 : !hl.int
-// CHECK:           } incr {
-// CHECK:             %8 = hl.ref %3 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
-// CHECK:             %9 = hl.post.inc %8 : !hl.lvalue<!hl.int> -> !hl.int
-// CHECK:           } do {
-// CHECK:             core.scope {
-// CHECK:               %8 = hl.call @foo() : () -> !hl.void
-// CHECK:             }
-// CHECK:           }
-// CHECK:         }
-// CHECK:       }
-// CHECK:       kernel.rcu.critical_section {
-// CHECK:         core.scope {
-// CHECK:           kernel.rcu.critical_section {
-// CHECK:           }
-// CHECK:         }
-// CHECK:       }
-// CHECK:       kernel.rcu.critical_section {
-// CHECK:         hl.do {
-// CHECK:           core.scope {
-// CHECK:             %5 = hl.var "x" : !hl.lvalue<!hl.int>
-// CHECK:           }
-// CHECK:         } while {
-// CHECK:           %5 = hl.const #core.integer<0> : !hl.int
-// CHECK:           hl.cond.yield %5 : !hl.int
-// CHECK:         }
-// CHECK:       }
-// CHECK:       kernel.rcu.critical_section {
-// CHECK:         kernel.rcu.critical_section {
-// CHECK:           kernel.rcu.critical_section {
-// CHECK:             kernel.rcu.critical_section {
-// CHECK:             }
-// CHECK:           }
-// CHECK:         }
-// CHECK:       }
-// CHECK:       kernel.rcu.critical_section {
-// CHECK:         hl.do {
-// CHECK:           core.scope {
-// CHECK:             kernel.rcu.critical_section {
-// CHECK:               %5 = hl.var "x" : !hl.lvalue<!hl.int>
-// CHECK:             }
-// CHECK:           }
-// CHECK:         } while {
-// CHECK:           %5 = hl.const #core.integer<0> : !hl.int
-// CHECK:           hl.cond.yield %5 : !hl.int
-// CHECK:         }
-// CHECK:       }
-// CHECK:       hl.do {
-// CHECK:         core.scope {
-// CHECK:           kernel.rcu.critical_section {
-// CHECK:             %5 = hl.var "x" : !hl.lvalue<!hl.int> = {
-// CHECK:               %7 = hl.const #core.integer<1> : !hl.int
-// CHECK:               hl.value.yield %7 : !hl.int
-// CHECK:             }
-// CHECK:             kernel.rcu.critical_section {
-// CHECK:             }
-// CHECK:             %6 = hl.var "y" : !hl.lvalue<!hl.int> = {
-// CHECK:               %7 = hl.const #core.integer<2> : !hl.int
-// CHECK:               hl.value.yield %7 : !hl.int
-// CHECK:             }
-// CHECK:           }
-// CHECK:         }
-// CHECK:       } while {
-// CHECK:         %5 = hl.const #core.integer<0> : !hl.int
-// CHECK:         hl.cond.yield %5 : !hl.int
-// CHECK:       }
-// CHECK:       kernel.rcu.critical_section {
-// CHECK:         hl.if {
-// CHECK:           %5 = hl.const #core.integer<1> : !hl.int
-// CHECK:           hl.cond.yield %5 : !hl.int
-// CHECK:         } then {
-// CHECK:           core.scope {
-// CHECK:             %5 = hl.call @rcu_read_unlock() {lock_level = 0 : i64} : () -> !hl.void
-// CHECK:           }
-// CHECK:         } else {
-// CHECK:           core.scope {
-// CHECK:             %5 = hl.call @rcu_read_lock() {lock_level = 0 : i64} : () -> !hl.void
-// CHECK:           }
-// CHECK:         }
-// CHECK:       }
-// CHECK:       kernel.rcu.critical_section {
-// CHECK:       }
-// CHECK:       hl.label %0 {
-// CHECK:       }
-// CHECK:       kernel.rcu.critical_section {
-// CHECK:         %5 = hl.const #core.integer<1> : !hl.int
-// CHECK:       }
-// CHECK:       hl.label %1 {
-// CHECK:       }
-// CHECK:       %4 = hl.const #core.integer<0> : !hl.int
-// CHECK:       hl.return %4 : !hl.int
-// CHECK:     }
-// CHECK:     %2 = hl.const #core.integer<0> : !hl.int
-// CHECK:     hl.return %2 : !hl.int
-// CHECK:   }
-// CHECK: }
-
 void rcu_read_lock(void) {}
 void rcu_read_unlock(void) {}
 
@@ -195,7 +28,6 @@ int main(void) {
                 foo();
         }
         rcu_read_unlock();
-
 
         rcu_read_lock();
         {
@@ -255,3 +87,171 @@ b_label:
 
         return 0;
 }
+
+// CHECK:hl.translation_unit {
+// CHECK:  hl.typedef "__int128_t" : !hl.int128
+// CHECK:  hl.typedef "__uint128_t" : !hl.int128< unsigned >
+// CHECK:  hl.struct "__NSConstantString_tag" {type_visibility = #unsup<attr "type_visibility">} : {
+// CHECK:    hl.field "isa" : !hl.ptr<!hl.int< const >>
+// CHECK:    hl.field "flags" : !hl.int
+// CHECK:    hl.field "str" : !hl.ptr<!hl.char< const >>
+// CHECK:    hl.field "length" : !hl.long
+// CHECK:  }
+// CHECK:  hl.typedef "__NSConstantString" : !hl.record<"__NSConstantString_tag">
+// CHECK:  hl.typedef "__builtin_ms_va_list" : !hl.ptr<!hl.char>
+// CHECK:  hl.struct "__va_list_tag" {type_visibility = #unsup<attr "type_visibility">} : {
+// CHECK:    hl.field "gp_offset" : !hl.int< unsigned >
+// CHECK:    hl.field "fp_offset" : !hl.int< unsigned >
+// CHECK:    hl.field "overflow_arg_area" : !hl.ptr<!hl.void>
+// CHECK:    hl.field "reg_save_area" : !hl.ptr<!hl.void>
+// CHECK:  }
+// CHECK:  hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
+// CHECK:  hl.func @rcu_read_lock () -> !hl.void {
+// CHECK:    core.scope {
+// CHECK:      %0 = hl.const #void_value
+// CHECK:      core.implicit.return %0 : !hl.void
+// CHECK:    }
+// CHECK:  }
+// CHECK:  hl.func @rcu_read_unlock () -> !hl.void {
+// CHECK:    core.scope {
+// CHECK:      %0 = hl.const #void_value
+// CHECK:      core.implicit.return %0 : !hl.void
+// CHECK:    }
+// CHECK:  }
+// CHECK:  hl.func @lock () -> !hl.void {
+// CHECK:    core.scope {
+// CHECK:      %0 = hl.call @rcu_read_lock() {lock_level = 0 : i64} : () -> !hl.void
+// CHECK:      %1 = hl.const #void_value
+// CHECK:      core.implicit.return %1 : !hl.void
+// CHECK:    }
+// CHECK:  }
+// CHECK:  hl.func @unlock () -> !hl.void {
+// CHECK:    core.scope {
+// CHECK:      %0 = hl.call @rcu_read_unlock() {lock_level = 0 : i64} : () -> !hl.void
+// CHECK:      %1 = hl.const #void_value
+// CHECK:      core.implicit.return %1 : !hl.void
+// CHECK:    }
+// CHECK:  }
+// CHECK:  hl.func @foo () -> !hl.void {
+// CHECK:    core.scope {
+// CHECK:      %0 = hl.const #void_value
+// CHECK:      core.implicit.return %0 : !hl.void
+// CHECK:    }
+// CHECK:  }
+// CHECK:  hl.func @main () -> !hl.int {
+// CHECK:    %0 = hl.label.decl "a_label" : !hl.label
+// CHECK:    %1 = hl.label.decl "b_label" : !hl.label
+// CHECK:    core.scope {
+// CHECK:      %3 = hl.var "i" : !hl.lvalue<!hl.int>
+// CHECK:      kernel.rcu.critical_section {
+// CHECK:      }
+// CHECK:      kernel.rcu.critical_section {
+// CHECK:        %5 = hl.call @foo() : () -> !hl.void
+// CHECK:      }
+// CHECK:      kernel.rcu.critical_section {
+// CHECK:        core.scope {
+// CHECK:          %5 = hl.ref %3 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
+// CHECK:          %6 = hl.const #core.integer<0> : !hl.int
+// CHECK:          %7 = hl.assign %6 to %5 : !hl.int, !hl.lvalue<!hl.int> -> !hl.int
+// CHECK:          hl.for {
+// CHECK:            %8 = hl.ref %3 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
+// CHECK:            %9 = hl.implicit_cast %8 LValueToRValue : !hl.lvalue<!hl.int> -> !hl.int
+// CHECK:            %10 = hl.const #core.integer<10> : !hl.int
+// CHECK:            %11 = hl.cmp slt %9, %10 : !hl.int, !hl.int -> !hl.int
+// CHECK:            hl.cond.yield %11 : !hl.int
+// CHECK:          } incr {
+// CHECK:            %8 = hl.ref %3 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
+// CHECK:            %9 = hl.post.inc %8 : !hl.lvalue<!hl.int> -> !hl.int
+// CHECK:          } do {
+// CHECK:            core.scope {
+// CHECK:              %8 = hl.call @foo() : () -> !hl.void
+// CHECK:            }
+// CHECK:          }
+// CHECK:        }
+// CHECK:      }
+// CHECK:      kernel.rcu.critical_section {
+// CHECK:        core.scope {
+// CHECK:          kernel.rcu.critical_section {
+// CHECK:          }
+// CHECK:        }
+// CHECK:      }
+// CHECK:      kernel.rcu.critical_section {
+// CHECK:        hl.do {
+// CHECK:          core.scope {
+// CHECK:            %5 = hl.var "x" : !hl.lvalue<!hl.int>
+// CHECK:          }
+// CHECK:        } while {
+// CHECK:          %5 = hl.const #core.integer<0> : !hl.int
+// CHECK:          hl.cond.yield %5 : !hl.int
+// CHECK:        }
+// CHECK:      }
+// CHECK:      kernel.rcu.critical_section {
+// CHECK:        kernel.rcu.critical_section {
+// CHECK:          kernel.rcu.critical_section {
+// CHECK:            kernel.rcu.critical_section {
+// CHECK:            }
+// CHECK:          }
+// CHECK:        }
+// CHECK:      }
+// CHECK:      kernel.rcu.critical_section {
+// CHECK:        hl.do {
+// CHECK:          core.scope {
+// CHECK:            kernel.rcu.critical_section {
+// CHECK:              %5 = hl.var "x" : !hl.lvalue<!hl.int>
+// CHECK:            }
+// CHECK:          }
+// CHECK:        } while {
+// CHECK:          %5 = hl.const #core.integer<0> : !hl.int
+// CHECK:          hl.cond.yield %5 : !hl.int
+// CHECK:        }
+// CHECK:      }
+// CHECK:      hl.do {
+// CHECK:        core.scope {
+// CHECK:          kernel.rcu.critical_section {
+// CHECK:            %5 = hl.var "x" : !hl.lvalue<!hl.int> = {
+// CHECK:              %7 = hl.const #core.integer<1> : !hl.int
+// CHECK:              hl.value.yield %7 : !hl.int
+// CHECK:            }
+// CHECK:            kernel.rcu.critical_section {
+// CHECK:            }
+// CHECK:            %6 = hl.var "y" : !hl.lvalue<!hl.int> = {
+// CHECK:              %7 = hl.const #core.integer<2> : !hl.int
+// CHECK:              hl.value.yield %7 : !hl.int
+// CHECK:            }
+// CHECK:          }
+// CHECK:        }
+// CHECK:      } while {
+// CHECK:        %5 = hl.const #core.integer<0> : !hl.int
+// CHECK:        hl.cond.yield %5 : !hl.int
+// CHECK:      }
+// CHECK:      kernel.rcu.critical_section {
+// CHECK:        hl.if {
+// CHECK:          %5 = hl.const #core.integer<1> : !hl.int
+// CHECK:          hl.cond.yield %5 : !hl.int
+// CHECK:        } then {
+// CHECK:          core.scope {
+// CHECK:            %5 = hl.call @rcu_read_unlock() {lock_level = 0 : i64} : () -> !hl.void
+// CHECK:          }
+// CHECK:        } else {
+// CHECK:          core.scope {
+// CHECK:            %5 = hl.call @rcu_read_lock() {lock_level = 0 : i64} : () -> !hl.void
+// CHECK:          }
+// CHECK:        }
+// CHECK:      }
+// CHECK:      kernel.rcu.critical_section {
+// CHECK:      }
+// CHECK:      hl.label %0 {
+// CHECK:      }
+// CHECK:      kernel.rcu.critical_section {
+// CHECK:        %5 = hl.const #core.integer<1> : !hl.int
+// CHECK:      }
+// CHECK:      hl.label %1 {
+// CHECK:      }
+// CHECK:      %4 = hl.const #core.integer<0> : !hl.int
+// CHECK:      hl.return %4 : !hl.int
+// CHECK:    }
+// CHECK:    %2 = hl.const #core.integer<0> : !hl.int
+// CHECK:    hl.return %2 : !hl.int
+// CHECK:  }
+// CHECK:}
+

--- a/test/KernelTests/rcu_replace_pointer.c
+++ b/test/KernelTests/rcu_replace_pointer.c
@@ -1,0 +1,50 @@
+// RUN: kernelize -x c %s | FileCheck %s --match-full-lines
+
+// CHECK: hl.translation_unit {
+// CHECK:   hl.typedef "__int128_t" : !hl.int128
+// CHECK:   hl.typedef "__uint128_t" : !hl.int128< unsigned >
+// CHECK:   hl.struct "__NSConstantString_tag" : {
+// CHECK:     hl.field "isa" : !hl.ptr<!hl.int< const >>
+// CHECK:     hl.field "flags" : !hl.int
+// CHECK:     hl.field "str" : !hl.ptr<!hl.char< const >>
+// CHECK:     hl.field "length" : !hl.long
+// CHECK:   }
+// CHECK:   hl.typedef "__NSConstantString" : !hl.record<"__NSConstantString_tag">
+// CHECK:   hl.typedef "__builtin_ms_va_list" : !hl.ptr<!hl.char>
+// CHECK:   hl.struct "__va_list_tag" : {
+// CHECK:     hl.field "gp_offset" : !hl.int< unsigned >
+// CHECK:     hl.field "fp_offset" : !hl.int< unsigned >
+// CHECK:     hl.field "overflow_arg_area" : !hl.ptr<!hl.void>
+// CHECK:     hl.field "reg_save_area" : !hl.ptr<!hl.void>
+// CHECK:   }
+// CHECK:   hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
+// CHECK:   hl.func @main () -> !hl.int {
+// CHECK:     core.scope {
+// CHECK:       %0 = hl.var "rcu_ptr" : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:       %1 = hl.var "ptr" : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:       %2 = macroni.parameter "rcu_ptr" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:         %7 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:         hl.value.yield %7 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:       }
+// CHECK:       %3 = macroni.parameter "ptr" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:         %7 = hl.ref %1 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:         hl.value.yield %7 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:       }
+// CHECK:       %4 = macroni.parameter "c" : !hl.int {
+// CHECK:         %7 = hl.const #core.integer<1> : !hl.int
+// CHECK:         hl.value.yield %7 : !hl.int
+// CHECK:       }
+// CHECK:       %5 = kernel.rcu_replace_pointer rcu_replace_pointer(%2, %3, %4) : (!hl.lvalue<!hl.ptr<!hl.int>>, !hl.lvalue<!hl.ptr<!hl.int>>, !hl.int) -> !hl.int
+// CHECK:       %6 = hl.const #core.integer<0> : !hl.int
+// CHECK:       hl.return %6 : !hl.int
+// CHECK:     }
+// CHECK:   }
+// CHECK: }
+
+#define rcu_replace_pointer(rcu_ptr, ptr, c) (c && ((rcu_ptr) = (ptr)))
+
+int main(void) {
+  int *rcu_ptr, *ptr;
+  rcu_replace_pointer(rcu_ptr, ptr, 1);
+  return 0;
+}

--- a/test/KernelTests/rcu_replace_pointer.c
+++ b/test/KernelTests/rcu_replace_pointer.c
@@ -1,46 +1,5 @@
 // RUN: kernelize -x c %s | FileCheck %s --match-full-lines
 
-// CHECK: hl.translation_unit {
-// CHECK:   hl.typedef "__int128_t" : !hl.int128
-// CHECK:   hl.typedef "__uint128_t" : !hl.int128< unsigned >
-// CHECK:   hl.struct "__NSConstantString_tag" : {
-// CHECK:     hl.field "isa" : !hl.ptr<!hl.int< const >>
-// CHECK:     hl.field "flags" : !hl.int
-// CHECK:     hl.field "str" : !hl.ptr<!hl.char< const >>
-// CHECK:     hl.field "length" : !hl.long
-// CHECK:   }
-// CHECK:   hl.typedef "__NSConstantString" : !hl.record<"__NSConstantString_tag">
-// CHECK:   hl.typedef "__builtin_ms_va_list" : !hl.ptr<!hl.char>
-// CHECK:   hl.struct "__va_list_tag" : {
-// CHECK:     hl.field "gp_offset" : !hl.int< unsigned >
-// CHECK:     hl.field "fp_offset" : !hl.int< unsigned >
-// CHECK:     hl.field "overflow_arg_area" : !hl.ptr<!hl.void>
-// CHECK:     hl.field "reg_save_area" : !hl.ptr<!hl.void>
-// CHECK:   }
-// CHECK:   hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
-// CHECK:   hl.func @main () -> !hl.int {
-// CHECK:     core.scope {
-// CHECK:       %0 = hl.var "rcu_ptr" : !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:       %1 = hl.var "ptr" : !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:       %2 = macroni.parameter "rcu_ptr" : !hl.lvalue<!hl.ptr<!hl.int>> {
-// CHECK:         %7 = hl.ref %0 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:         hl.value.yield %7 : !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:       }
-// CHECK:       %3 = macroni.parameter "ptr" : !hl.lvalue<!hl.ptr<!hl.int>> {
-// CHECK:         %7 = hl.ref %1 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:         hl.value.yield %7 : !hl.lvalue<!hl.ptr<!hl.int>>
-// CHECK:       }
-// CHECK:       %4 = macroni.parameter "c" : !hl.int {
-// CHECK:         %7 = hl.const #core.integer<1> : !hl.int
-// CHECK:         hl.value.yield %7 : !hl.int
-// CHECK:       }
-// CHECK:       %5 = kernel.rcu_replace_pointer rcu_replace_pointer(%2, %3, %4) : (!hl.lvalue<!hl.ptr<!hl.int>>, !hl.lvalue<!hl.ptr<!hl.int>>, !hl.int) -> !hl.int
-// CHECK:       %6 = hl.const #core.integer<0> : !hl.int
-// CHECK:       hl.return %6 : !hl.int
-// CHECK:     }
-// CHECK:   }
-// CHECK: }
-
 #define rcu_replace_pointer(rcu_ptr, ptr, c) (c && ((rcu_ptr) = (ptr)))
 
 int main(void) {
@@ -48,3 +7,45 @@ int main(void) {
   rcu_replace_pointer(rcu_ptr, ptr, 1);
   return 0;
 }
+
+// CHECK:hl.translation_unit {
+// CHECK:  hl.typedef "__int128_t" : !hl.int128
+// CHECK:  hl.typedef "__uint128_t" : !hl.int128< unsigned >
+// CHECK:  hl.struct "__NSConstantString_tag" {type_visibility = #unsup<attr "type_visibility">} : {
+// CHECK:    hl.field "isa" : !hl.ptr<!hl.int< const >>
+// CHECK:    hl.field "flags" : !hl.int
+// CHECK:    hl.field "str" : !hl.ptr<!hl.char< const >>
+// CHECK:    hl.field "length" : !hl.long
+// CHECK:  }
+// CHECK:  hl.typedef "__NSConstantString" : !hl.record<"__NSConstantString_tag">
+// CHECK:  hl.typedef "__builtin_ms_va_list" : !hl.ptr<!hl.char>
+// CHECK:  hl.struct "__va_list_tag" {type_visibility = #unsup<attr "type_visibility">} : {
+// CHECK:    hl.field "gp_offset" : !hl.int< unsigned >
+// CHECK:    hl.field "fp_offset" : !hl.int< unsigned >
+// CHECK:    hl.field "overflow_arg_area" : !hl.ptr<!hl.void>
+// CHECK:    hl.field "reg_save_area" : !hl.ptr<!hl.void>
+// CHECK:  }
+// CHECK:  hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
+// CHECK:  hl.func @main () -> !hl.int {
+// CHECK:    core.scope {
+// CHECK:      %0 = hl.var "rcu_ptr" : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:      %1 = hl.var "ptr" : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:      %2 = macroni.parameter "ptr" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:        %7 = hl.ref %1 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:        hl.value.yield %7 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:      }
+// CHECK:      %3 = macroni.parameter "ptr" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:        %7 = hl.ref %1 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:        hl.value.yield %7 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:      }
+// CHECK:      %4 = macroni.parameter "ptr" : !hl.lvalue<!hl.ptr<!hl.int>> {
+// CHECK:        %7 = hl.ref %1 : (!hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:        hl.value.yield %7 : !hl.lvalue<!hl.ptr<!hl.int>>
+// CHECK:      }
+// CHECK:      %5 = kernel.rcu_replace_pointer(%2, %3, %4) : (!hl.lvalue<!hl.ptr<!hl.int>>, !hl.lvalue<!hl.ptr<!hl.int>>, !hl.lvalue<!hl.ptr<!hl.int>>) -> !hl.int
+// CHECK:      %6 = hl.const #core.integer<0> : !hl.int
+// CHECK:      hl.return %6 : !hl.int
+// CHECK:    }
+// CHECK:  }
+// CHECK:}
+

--- a/test/KernelTests/rcu_warnings.c
+++ b/test/KernelTests/rcu_warnings.c
@@ -1,17 +1,5 @@
 // RUN: kernelize -x c %s 2>&1 1>/dev/null | FileCheck %s
 
-// CHECK: warning: Invocation of rcu_dereference_bh() outside of RCU critical section
-// CHECK: warning: Invocation of rcu_dereference_sched() outside of RCU critical section
-// CHECK: warning: Invocation of rcu_dereference_check() outside of RCU critical section
-// CHECK: warning: Invocation of rcu_dereference_bh_check() outside of RCU critical section
-// CHECK: warning: Invocation of rcu_dereference_sched_check() outside of RCU critical section
-// CHECK: warning: Invocation of rcu_dereference_protected() outside of RCU critical section
-// CHECK: warning: Invocation of rcu_access_pointer() outside of RCU critical section
-// CHECK: warning: Invocation of rcu_assign_pointer() outside of RCU critical section
-// CHECK: warning: Invocation of rcu_replace_pointer() outside of RCU critical section
-// CHECK: warning: Invocation of rcu_dereference() outside of RCU critical section
-// CHECK: suggestion: Use rcu_dereference_protected() instead of rcu_access_pointer()
-
 #define __must_hold(x) __attribute__((context(x, 1, 1)))
 #define __acquires(x) __attribute__((context(x, 0, 1)))
 #define __releases(x) __attribute__((context(x, 1, 0)))
@@ -143,3 +131,25 @@ int main(void) {
 
         return 0;
 }
+
+// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:44:9: warning: Invocation of rcu_dereference() outside of RCU critical section
+// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:45:9: warning: Invocation of rcu_dereference_bh() outside of RCU critical section
+// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:46:9: warning: Invocation of rcu_dereference_sched() outside of RCU critical section
+// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:18:19: warning: Invocation of rcu_dereference() outside of RCU critical section
+// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:58:9: warning: Invocation of rcu_dereference() outside of RCU critical section
+// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:59:9: warning: Invocation of rcu_dereference_bh() outside of RCU critical section
+// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:60:9: warning: Invocation of rcu_dereference_sched() outside of RCU critical section
+// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:18:19: warning: Invocation of rcu_dereference() outside of RCU critical section
+// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:18:19: warning: Invocation of rcu_dereference() outside of RCU critical section
+// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:91:9: warning: Invocation of rcu_dereference_sched() outside of RCU critical section
+// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:90:9: warning: Invocation of rcu_dereference_bh() outside of RCU critical section
+// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:89:9: warning: Invocation of rcu_dereference() outside of RCU critical section
+// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:18:19: warning: Invocation of rcu_dereference() outside of RCU critical section
+// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:77:9: warning: Invocation of rcu_dereference_sched() outside of RCU critical section
+// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:76:9: warning: Invocation of rcu_dereference_bh() outside of RCU critical section
+// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:75:9: warning: Invocation of rcu_dereference() outside of RCU critical section
+// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:106:9: warning: Invocation of rcu_dereference() outside of RCU critical section
+// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:107:9: warning: Invocation of rcu_dereference_bh() outside of RCU critical section
+// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:108:9: warning: Invocation of rcu_dereference_sched() outside of RCU critical section
+// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:18:19: warning: Invocation of rcu_dereference() outside of RCU critical section
+

--- a/test/KernelTests/rcu_warnings.c
+++ b/test/KernelTests/rcu_warnings.c
@@ -12,6 +12,10 @@
 // CHECK: warning: Invocation of rcu_dereference() outside of RCU critical section
 // CHECK: suggestion: Use rcu_dereference_protected() instead of rcu_access_pointer()
 
+#define __must_hold(x) __attribute__((context(x, 1, 1)))
+#define __acquires(x) __attribute__((context(x, 0, 1)))
+#define __releases(x) __attribute__((context(x, 1, 0)))
+
 #define rcu_dereference(p) (*p)
 #define rcu_dereference_bh(p) (*p)
 #define rcu_dereference_sched(p) (*p)
@@ -27,6 +31,85 @@
 
 void rcu_read_lock(void) {}
 void rcu_read_unlock(void) {}
+
+void must_hold_test(int lock) __must_hold(lock)  {
+        int *p = (int *) 0xC0FFEE;
+        int *v;
+
+        rcu_dereference(p);
+        rcu_dereference_bh(p);
+        rcu_dereference_sched(p);
+        rcu_dereference_check(p, 1);
+        rcu_dereference_bh_check(p, 1);
+        rcu_dereference_sched_check(p, 1);
+        rcu_dereference_protected(p, 1);
+        rcu_access_pointer(p);
+        rcu_assign_pointer(p, v);
+        rcu_replace_pointer(p, v, 1);
+        deref(p);
+}
+
+void acquires_test(int lock) __acquires(lock)  {
+        int *p = (int *) 0xC0FFEE;
+        int *v;
+
+        rcu_dereference(p);
+        rcu_dereference_bh(p);
+        rcu_dereference_sched(p);
+        rcu_dereference_check(p, 1);
+        rcu_dereference_bh_check(p, 1);
+        rcu_dereference_sched_check(p, 1);
+        rcu_dereference_protected(p, 1);
+        rcu_access_pointer(p);
+        rcu_assign_pointer(p, v);
+        rcu_replace_pointer(p, v, 1);
+        deref(p);
+
+        rcu_read_lock();
+
+        rcu_dereference(p);
+        rcu_dereference_bh(p);
+        rcu_dereference_sched(p);
+        rcu_dereference_check(p, 1);
+        rcu_dereference_bh_check(p, 1);
+        rcu_dereference_sched_check(p, 1);
+        rcu_dereference_protected(p, 1);
+        rcu_access_pointer(p);
+        rcu_assign_pointer(p, v);
+        rcu_replace_pointer(p, v, 1);
+        deref(p);
+}
+
+void releases_test(int lock) __releases(lock)  {
+        int *p = (int *) 0xC0FFEE;
+        int *v;
+
+        rcu_dereference(p);
+        rcu_dereference_bh(p);
+        rcu_dereference_sched(p);
+        rcu_dereference_check(p, 1);
+        rcu_dereference_bh_check(p, 1);
+        rcu_dereference_sched_check(p, 1);
+        rcu_dereference_protected(p, 1);
+        rcu_access_pointer(p);
+        rcu_assign_pointer(p, v);
+        rcu_replace_pointer(p, v, 1);
+        deref(p);
+
+        rcu_read_unlock();
+
+        rcu_dereference(p);
+        rcu_dereference_bh(p);
+        rcu_dereference_sched(p);
+        rcu_dereference_check(p, 1);
+        rcu_dereference_bh_check(p, 1);
+        rcu_dereference_sched_check(p, 1);
+        rcu_dereference_protected(p, 1);
+        rcu_access_pointer(p);
+        rcu_assign_pointer(p, v);
+        rcu_replace_pointer(p, v, 1);
+        deref(p);
+}
 
 int main(void) {
         int *p = (int *) 0xC0FFEE;

--- a/test/KernelTests/smp_mb.c
+++ b/test/KernelTests/smp_mb.c
@@ -1,39 +1,5 @@
 // RUN: kernelize -x c %s | FileCheck %s --match-full-lines
 
-// CHECK: hl.translation_unit {
-// CHECK:   hl.typedef "__int128_t" : !hl.int128
-// CHECK:   hl.typedef "__uint128_t" : !hl.int128< unsigned >
-// CHECK:   hl.struct "__NSConstantString_tag" : {
-// CHECK:     hl.field "isa" : !hl.ptr<!hl.int< const >>
-// CHECK:     hl.field "flags" : !hl.int
-// CHECK:     hl.field "str" : !hl.ptr<!hl.char< const >>
-// CHECK:     hl.field "length" : !hl.long
-// CHECK:   }
-// CHECK:   hl.typedef "__NSConstantString" : !hl.record<"__NSConstantString_tag">
-// CHECK:   hl.typedef "__builtin_ms_va_list" : !hl.ptr<!hl.char>
-// CHECK:   hl.struct "__va_list_tag" : {
-// CHECK:     hl.field "gp_offset" : !hl.int< unsigned >
-// CHECK:     hl.field "fp_offset" : !hl.int< unsigned >
-// CHECK:     hl.field "overflow_arg_area" : !hl.ptr<!hl.void>
-// CHECK:     hl.field "reg_save_area" : !hl.ptr<!hl.void>
-// CHECK:   }
-// CHECK:   hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
-// CHECK:   hl.func @barrier () -> !hl.int {
-// CHECK:     core.scope {
-// CHECK:       %0 = hl.const #core.integer<0> : !hl.int
-// CHECK:       hl.return %0 : !hl.int
-// CHECK:     }
-// CHECK:   }
-// CHECK:   hl.func @main () -> !hl.int {
-// CHECK:     core.scope {
-// CHECK:       %0 = kernel.smp_mb smp_mb() : () -> !hl.int
-// CHECK:       %1 = hl.const #core.integer<0> : !hl.int
-// CHECK:       hl.return %1 : !hl.int
-// CHECK:     }
-// CHECK:   }
-// CHECK: }
-
-
 int barrier(void) { return 0; }
 #define smp_mb() barrier()
 
@@ -41,3 +7,37 @@ int main(void) {
         smp_mb();
         return 0;
 }
+
+// CHECK:hl.translation_unit {
+// CHECK:  hl.typedef "__int128_t" : !hl.int128
+// CHECK:  hl.typedef "__uint128_t" : !hl.int128< unsigned >
+// CHECK:  hl.struct "__NSConstantString_tag" {type_visibility = #unsup<attr "type_visibility">} : {
+// CHECK:    hl.field "isa" : !hl.ptr<!hl.int< const >>
+// CHECK:    hl.field "flags" : !hl.int
+// CHECK:    hl.field "str" : !hl.ptr<!hl.char< const >>
+// CHECK:    hl.field "length" : !hl.long
+// CHECK:  }
+// CHECK:  hl.typedef "__NSConstantString" : !hl.record<"__NSConstantString_tag">
+// CHECK:  hl.typedef "__builtin_ms_va_list" : !hl.ptr<!hl.char>
+// CHECK:  hl.struct "__va_list_tag" {type_visibility = #unsup<attr "type_visibility">} : {
+// CHECK:    hl.field "gp_offset" : !hl.int< unsigned >
+// CHECK:    hl.field "fp_offset" : !hl.int< unsigned >
+// CHECK:    hl.field "overflow_arg_area" : !hl.ptr<!hl.void>
+// CHECK:    hl.field "reg_save_area" : !hl.ptr<!hl.void>
+// CHECK:  }
+// CHECK:  hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
+// CHECK:  hl.func @barrier () -> !hl.int {
+// CHECK:    core.scope {
+// CHECK:      %0 = hl.const #core.integer<0> : !hl.int
+// CHECK:      hl.return %0 : !hl.int
+// CHECK:    }
+// CHECK:  }
+// CHECK:  hl.func @main () -> !hl.int {
+// CHECK:    core.scope {
+// CHECK:      %0 = kernel.smp_mb() : () -> !hl.int
+// CHECK:      %1 = hl.const #core.integer<0> : !hl.int
+// CHECK:      hl.return %1 : !hl.int
+// CHECK:    }
+// CHECK:  }
+// CHECK:}
+

--- a/test/MacroniTests/function_like.c
+++ b/test/MacroniTests/function_like.c
@@ -1,466 +1,5 @@
 // RUN: macronify -xc %s | FileCheck %s --match-full-lines
 
-// CHECK: hl.translation_unit {
-// CHECK:   hl.typedef "__int128_t" : !hl.int128
-// CHECK:   hl.typedef "__uint128_t" : !hl.int128< unsigned >
-// CHECK:   hl.struct "__NSConstantString_tag" : {
-// CHECK:     hl.field "isa" : !hl.ptr<!hl.int< const >>
-// CHECK:     hl.field "flags" : !hl.int
-// CHECK:     hl.field "str" : !hl.ptr<!hl.char< const >>
-// CHECK:     hl.field "length" : !hl.long
-// CHECK:   }
-// CHECK:   hl.typedef "__NSConstantString" : !hl.record<"__NSConstantString_tag">
-// CHECK:   hl.typedef "__builtin_ms_va_list" : !hl.ptr<!hl.char>
-// CHECK:   hl.struct "__va_list_tag" : {
-// CHECK:     hl.field "gp_offset" : !hl.int< unsigned >
-// CHECK:     hl.field "fp_offset" : !hl.int< unsigned >
-// CHECK:     hl.field "overflow_arg_area" : !hl.ptr<!hl.void>
-// CHECK:     hl.field "reg_save_area" : !hl.ptr<!hl.void>
-// CHECK:   }
-// CHECK:   hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
-// CHECK:   %0 = hl.var "a" : !hl.lvalue<!hl.int> = {
-// CHECK:     %14 = macroni.expansion "ONE" : !hl.int {
-// CHECK:       %15 = hl.const #core.integer<1> : !hl.int
-// CHECK:       hl.value.yield %15 : !hl.int
-// CHECK:     }
-// CHECK:     hl.value.yield %14 : !hl.int
-// CHECK:   }
-// CHECK:   %1 = hl.var "b" : !hl.lvalue<!hl.int> = {
-// CHECK:     %14 = macroni.expansion "ONE" : !hl.int {
-// CHECK:       %17 = hl.const #core.integer<1> : !hl.int
-// CHECK:       hl.value.yield %17 : !hl.int
-// CHECK:     }
-// CHECK:     %15 = macroni.expansion "ONE" : !hl.int {
-// CHECK:       %17 = hl.const #core.integer<1> : !hl.int
-// CHECK:       hl.value.yield %17 : !hl.int
-// CHECK:     }
-// CHECK:     %16 = hl.add %14, %15 : (!hl.int, !hl.int) -> !hl.int
-// CHECK:     hl.value.yield %16 : !hl.int
-// CHECK:   }
-// CHECK:   %2 = hl.var "c" : !hl.lvalue<!hl.int> = {
-// CHECK:     %14 = macroni.expansion "ADD(X, Y)" : !hl.int {
-// CHECK:       %15 = macroni.parameter "X" : !hl.int {
-// CHECK:         %18 = hl.const #core.integer<1> : !hl.int
-// CHECK:         hl.value.yield %18 : !hl.int
-// CHECK:       }
-// CHECK:       %16 = macroni.parameter "Y" : !hl.int {
-// CHECK:         %18 = hl.const #core.integer<1> : !hl.int
-// CHECK:         hl.value.yield %18 : !hl.int
-// CHECK:       }
-// CHECK:       %17 = hl.add %15, %16 : (!hl.int, !hl.int) -> !hl.int
-// CHECK:       hl.value.yield %17 : !hl.int
-// CHECK:     }
-// CHECK:     hl.value.yield %14 : !hl.int
-// CHECK:   }
-// CHECK:   %3 = hl.var "d" : !hl.lvalue<!hl.int> = {
-// CHECK:     %14 = macroni.expansion "ADD(X, Y)" : !hl.int {
-// CHECK:       %15 = macroni.parameter "X" : !hl.int {
-// CHECK:         %18 = hl.const #core.integer<1> : !hl.int
-// CHECK:         hl.value.yield %18 : !hl.int
-// CHECK:       }
-// CHECK:       %16 = macroni.parameter "Y" : !hl.int {
-// CHECK:         %18 = macroni.expansion "ONE" : !hl.int {
-// CHECK:           %19 = hl.const #core.integer<1> : !hl.int
-// CHECK:           hl.value.yield %19 : !hl.int
-// CHECK:         }
-// CHECK:         hl.value.yield %18 : !hl.int
-// CHECK:       }
-// CHECK:       %17 = hl.add %15, %16 : (!hl.int, !hl.int) -> !hl.int
-// CHECK:       hl.value.yield %17 : !hl.int
-// CHECK:     }
-// CHECK:     hl.value.yield %14 : !hl.int
-// CHECK:   }
-// CHECK:   %4 = hl.var "e" : !hl.lvalue<!hl.int> = {
-// CHECK:     %14 = macroni.expansion "ADD(X, Y)" : !hl.int {
-// CHECK:       %15 = macroni.parameter "X" : !hl.int {
-// CHECK:         %18 = macroni.expansion "ONE" : !hl.int {
-// CHECK:           %19 = hl.const #core.integer<1> : !hl.int
-// CHECK:           hl.value.yield %19 : !hl.int
-// CHECK:         }
-// CHECK:         hl.value.yield %18 : !hl.int
-// CHECK:       }
-// CHECK:       %16 = macroni.parameter "Y" : !hl.int {
-// CHECK:         %18 = hl.const #core.integer<1> : !hl.int
-// CHECK:         hl.value.yield %18 : !hl.int
-// CHECK:       }
-// CHECK:       %17 = hl.add %15, %16 : (!hl.int, !hl.int) -> !hl.int
-// CHECK:       hl.value.yield %17 : !hl.int
-// CHECK:     }
-// CHECK:     hl.value.yield %14 : !hl.int
-// CHECK:   }
-// CHECK:   %5 = hl.var "f" : !hl.lvalue<!hl.int> = {
-// CHECK:     %14 = macroni.expansion "ADD(X, Y)" : !hl.int {
-// CHECK:       %15 = macroni.parameter "X" : !hl.int {
-// CHECK:         %18 = macroni.expansion "ONE" : !hl.int {
-// CHECK:           %19 = hl.const #core.integer<1> : !hl.int
-// CHECK:           hl.value.yield %19 : !hl.int
-// CHECK:         }
-// CHECK:         hl.value.yield %18 : !hl.int
-// CHECK:       }
-// CHECK:       %16 = macroni.parameter "Y" : !hl.int {
-// CHECK:         %18 = macroni.expansion "ONE" : !hl.int {
-// CHECK:           %19 = hl.const #core.integer<1> : !hl.int
-// CHECK:           hl.value.yield %19 : !hl.int
-// CHECK:         }
-// CHECK:         hl.value.yield %18 : !hl.int
-// CHECK:       }
-// CHECK:       %17 = hl.add %15, %16 : (!hl.int, !hl.int) -> !hl.int
-// CHECK:       hl.value.yield %17 : !hl.int
-// CHECK:     }
-// CHECK:     hl.value.yield %14 : !hl.int
-// CHECK:   }
-// CHECK:   %6 = hl.var "g" : !hl.lvalue<!hl.int> = {
-// CHECK:     %14 = macroni.expansion "ADD(X, Y)" : !hl.int {
-// CHECK:       %15 = macroni.parameter "X" : !hl.int {
-// CHECK:         %18 = macroni.expansion "MUL(A, B)" : !hl.int {
-// CHECK:           %19 = macroni.parameter "A" : !hl.int {
-// CHECK:             %22 = hl.const #core.integer<1> : !hl.int
-// CHECK:             hl.value.yield %22 : !hl.int
-// CHECK:           }
-// CHECK:           %20 = macroni.parameter "B" : !hl.int {
-// CHECK:             %22 = hl.const #core.integer<2> : !hl.int
-// CHECK:             hl.value.yield %22 : !hl.int
-// CHECK:           }
-// CHECK:           %21 = hl.mul %19, %20 : (!hl.int, !hl.int) -> !hl.int
-// CHECK:           hl.value.yield %21 : !hl.int
-// CHECK:         }
-// CHECK:         hl.value.yield %18 : !hl.int
-// CHECK:       }
-// CHECK:       %16 = macroni.parameter "Y" : !hl.int {
-// CHECK:         %18 = hl.const #core.integer<3> : !hl.int
-// CHECK:         hl.value.yield %18 : !hl.int
-// CHECK:       }
-// CHECK:       %17 = hl.add %15, %16 : (!hl.int, !hl.int) -> !hl.int
-// CHECK:       hl.value.yield %17 : !hl.int
-// CHECK:     }
-// CHECK:     hl.value.yield %14 : !hl.int
-// CHECK:   }
-// CHECK:   %7 = hl.var "h" : !hl.lvalue<!hl.int> = {
-// CHECK:     %14 = macroni.expansion "ADD(X, Y)" : !hl.int {
-// CHECK:       %15 = macroni.parameter "X" : !hl.int {
-// CHECK:         %18 = hl.const #core.integer<1> : !hl.int
-// CHECK:         hl.value.yield %18 : !hl.int
-// CHECK:       }
-// CHECK:       %16 = macroni.parameter "Y" : !hl.int {
-// CHECK:         %18 = macroni.expansion "MUL(A, B)" : !hl.int {
-// CHECK:           %19 = macroni.parameter "A" : !hl.int {
-// CHECK:             %22 = hl.const #core.integer<2> : !hl.int
-// CHECK:             hl.value.yield %22 : !hl.int
-// CHECK:           }
-// CHECK:           %20 = macroni.parameter "B" : !hl.int {
-// CHECK:             %22 = hl.const #core.integer<3> : !hl.int
-// CHECK:             hl.value.yield %22 : !hl.int
-// CHECK:           }
-// CHECK:           %21 = hl.mul %19, %20 : (!hl.int, !hl.int) -> !hl.int
-// CHECK:           hl.value.yield %21 : !hl.int
-// CHECK:         }
-// CHECK:         hl.value.yield %18 : !hl.int
-// CHECK:       }
-// CHECK:       %17 = hl.add %15, %16 : (!hl.int, !hl.int) -> !hl.int
-// CHECK:       hl.value.yield %17 : !hl.int
-// CHECK:     }
-// CHECK:     hl.value.yield %14 : !hl.int
-// CHECK:   }
-// CHECK:   %8 = hl.var "i" : !hl.lvalue<!hl.int> = {
-// CHECK:     %14 = macroni.expansion "ADD(X, Y)" : !hl.int {
-// CHECK:       %15 = macroni.parameter "X" : !hl.int {
-// CHECK:         %18 = macroni.expansion "ONE" : !hl.int {
-// CHECK:           %19 = hl.const #core.integer<1> : !hl.int
-// CHECK:           hl.value.yield %19 : !hl.int
-// CHECK:         }
-// CHECK:         hl.value.yield %18 : !hl.int
-// CHECK:       }
-// CHECK:       %16 = macroni.parameter "Y" : !hl.int {
-// CHECK:         %18 = macroni.expansion "MUL(A, B)" : !hl.int {
-// CHECK:           %19 = macroni.parameter "A" : !hl.int {
-// CHECK:             %22 = hl.const #core.integer<2> : !hl.int
-// CHECK:             hl.value.yield %22 : !hl.int
-// CHECK:           }
-// CHECK:           %20 = macroni.parameter "B" : !hl.int {
-// CHECK:             %22 = hl.const #core.integer<3> : !hl.int
-// CHECK:             hl.value.yield %22 : !hl.int
-// CHECK:           }
-// CHECK:           %21 = hl.mul %19, %20 : (!hl.int, !hl.int) -> !hl.int
-// CHECK:           hl.value.yield %21 : !hl.int
-// CHECK:         }
-// CHECK:         hl.value.yield %18 : !hl.int
-// CHECK:       }
-// CHECK:       %17 = hl.add %15, %16 : (!hl.int, !hl.int) -> !hl.int
-// CHECK:       hl.value.yield %17 : !hl.int
-// CHECK:     }
-// CHECK:     hl.value.yield %14 : !hl.int
-// CHECK:   }
-// CHECK:   %9 = hl.var "j" : !hl.lvalue<!hl.int> = {
-// CHECK:     %14 = macroni.expansion "ADD(X, Y)" : !hl.int {
-// CHECK:       %15 = macroni.parameter "X" : !hl.int {
-// CHECK:         %18 = macroni.expansion "ONE" : !hl.int {
-// CHECK:           %19 = hl.const #core.integer<1> : !hl.int
-// CHECK:           hl.value.yield %19 : !hl.int
-// CHECK:         }
-// CHECK:         hl.value.yield %18 : !hl.int
-// CHECK:       }
-// CHECK:       %16 = macroni.parameter "Y" : !hl.int {
-// CHECK:         %18 = macroni.expansion "MUL(A, B)" : !hl.int {
-// CHECK:           %19 = macroni.parameter "A" : !hl.int {
-// CHECK:             %22 = macroni.expansion "ONE" : !hl.int {
-// CHECK:               %23 = hl.const #core.integer<1> : !hl.int
-// CHECK:               hl.value.yield %23 : !hl.int
-// CHECK:             }
-// CHECK:             hl.value.yield %22 : !hl.int
-// CHECK:           }
-// CHECK:           %20 = macroni.parameter "B" : !hl.int {
-// CHECK:             %22 = macroni.expansion "ONE" : !hl.int {
-// CHECK:               %23 = hl.const #core.integer<1> : !hl.int
-// CHECK:               hl.value.yield %23 : !hl.int
-// CHECK:             }
-// CHECK:             hl.value.yield %22 : !hl.int
-// CHECK:           }
-// CHECK:           %21 = hl.mul %19, %20 : (!hl.int, !hl.int) -> !hl.int
-// CHECK:           hl.value.yield %21 : !hl.int
-// CHECK:         }
-// CHECK:         hl.value.yield %18 : !hl.int
-// CHECK:       }
-// CHECK:       %17 = hl.add %15, %16 : (!hl.int, !hl.int) -> !hl.int
-// CHECK:       hl.value.yield %17 : !hl.int
-// CHECK:     }
-// CHECK:     hl.value.yield %14 : !hl.int
-// CHECK:   }
-// CHECK:   %10 = hl.var "k" : !hl.lvalue<!hl.int> = {
-// CHECK:     %14 = macroni.expansion "ADD(X, Y)" : !hl.int {
-// CHECK:       %15 = macroni.parameter "X" : !hl.int {
-// CHECK:         %18 = macroni.expansion "MUL(A, B)" : !hl.int {
-// CHECK:           %19 = macroni.parameter "A" : !hl.int {
-// CHECK:             %22 = hl.const #core.integer<1> : !hl.int
-// CHECK:             hl.value.yield %22 : !hl.int
-// CHECK:           }
-// CHECK:           %20 = macroni.parameter "B" : !hl.int {
-// CHECK:             %22 = hl.const #core.integer<2> : !hl.int
-// CHECK:             hl.value.yield %22 : !hl.int
-// CHECK:           }
-// CHECK:           %21 = hl.mul %19, %20 : (!hl.int, !hl.int) -> !hl.int
-// CHECK:           hl.value.yield %21 : !hl.int
-// CHECK:         }
-// CHECK:         hl.value.yield %18 : !hl.int
-// CHECK:       }
-// CHECK:       %16 = macroni.parameter "Y" : !hl.int {
-// CHECK:         %18 = hl.const #core.integer<3> : !hl.int
-// CHECK:         hl.value.yield %18 : !hl.int
-// CHECK:       }
-// CHECK:       %17 = hl.add %15, %16 : (!hl.int, !hl.int) -> !hl.int
-// CHECK:       hl.value.yield %17 : !hl.int
-// CHECK:     }
-// CHECK:     hl.value.yield %14 : !hl.int
-// CHECK:   }
-// CHECK:   %11 = hl.var "l" : !hl.lvalue<!hl.int> = {
-// CHECK:     %14 = macroni.expansion "ADD(X, Y)" : !hl.int {
-// CHECK:       %15 = macroni.parameter "X" : !hl.int {
-// CHECK:         %18 = macroni.expansion "MUL(A, B)" : !hl.int {
-// CHECK:           %19 = macroni.parameter "A" : !hl.int {
-// CHECK:             %22 = hl.const #core.integer<1> : !hl.int
-// CHECK:             hl.value.yield %22 : !hl.int
-// CHECK:           }
-// CHECK:           %20 = macroni.parameter "B" : !hl.int {
-// CHECK:             %22 = hl.const #core.integer<2> : !hl.int
-// CHECK:             hl.value.yield %22 : !hl.int
-// CHECK:           }
-// CHECK:           %21 = hl.mul %19, %20 : (!hl.int, !hl.int) -> !hl.int
-// CHECK:           hl.value.yield %21 : !hl.int
-// CHECK:         }
-// CHECK:         hl.value.yield %18 : !hl.int
-// CHECK:       }
-// CHECK:       %16 = macroni.parameter "Y" : !hl.int {
-// CHECK:         %18 = macroni.expansion "ONE" : !hl.int {
-// CHECK:           %19 = hl.const #core.integer<1> : !hl.int
-// CHECK:           hl.value.yield %19 : !hl.int
-// CHECK:         }
-// CHECK:         hl.value.yield %18 : !hl.int
-// CHECK:       }
-// CHECK:       %17 = hl.add %15, %16 : (!hl.int, !hl.int) -> !hl.int
-// CHECK:       hl.value.yield %17 : !hl.int
-// CHECK:     }
-// CHECK:     hl.value.yield %14 : !hl.int
-// CHECK:   }
-// CHECK:   %12 = hl.var "m" : !hl.lvalue<!hl.int> = {
-// CHECK:     %14 = macroni.expansion "ADD(X, Y)" : !hl.int {
-// CHECK:       %15 = macroni.parameter "X" : !hl.int {
-// CHECK:         %18 = macroni.expansion "MUL(A, B)" : !hl.int {
-// CHECK:           %19 = macroni.parameter "A" : !hl.int {
-// CHECK:             %22 = hl.const #core.integer<1> : !hl.int
-// CHECK:             hl.value.yield %22 : !hl.int
-// CHECK:           }
-// CHECK:           %20 = macroni.parameter "B" : !hl.int {
-// CHECK:             %22 = hl.const #core.integer<2> : !hl.int
-// CHECK:             hl.value.yield %22 : !hl.int
-// CHECK:           }
-// CHECK:           %21 = hl.mul %19, %20 : (!hl.int, !hl.int) -> !hl.int
-// CHECK:           hl.value.yield %21 : !hl.int
-// CHECK:         }
-// CHECK:         hl.value.yield %18 : !hl.int
-// CHECK:       }
-// CHECK:       %16 = macroni.parameter "Y" : !hl.int {
-// CHECK:         %18 = macroni.expansion "MUL(A, B)" : !hl.int {
-// CHECK:           %19 = macroni.parameter "A" : !hl.int {
-// CHECK:             %22 = macroni.expansion "ONE" : !hl.int {
-// CHECK:               %23 = hl.const #core.integer<1> : !hl.int
-// CHECK:               hl.value.yield %23 : !hl.int
-// CHECK:             }
-// CHECK:             hl.value.yield %22 : !hl.int
-// CHECK:           }
-// CHECK:           %20 = macroni.parameter "B" : !hl.int {
-// CHECK:             %22 = macroni.expansion "ONE" : !hl.int {
-// CHECK:               %23 = hl.const #core.integer<1> : !hl.int
-// CHECK:               hl.value.yield %23 : !hl.int
-// CHECK:             }
-// CHECK:             hl.value.yield %22 : !hl.int
-// CHECK:           }
-// CHECK:           %21 = hl.mul %19, %20 : (!hl.int, !hl.int) -> !hl.int
-// CHECK:           hl.value.yield %21 : !hl.int
-// CHECK:         }
-// CHECK:         hl.value.yield %18 : !hl.int
-// CHECK:       }
-// CHECK:       %17 = hl.add %15, %16 : (!hl.int, !hl.int) -> !hl.int
-// CHECK:       hl.value.yield %17 : !hl.int
-// CHECK:     }
-// CHECK:     hl.value.yield %14 : !hl.int
-// CHECK:   }
-// CHECK:   %13 = hl.var "n" : !hl.lvalue<!hl.int> = {
-// CHECK:     %14 = macroni.expansion "ADD(X, Y)" : !hl.int {
-// CHECK:       %15 = macroni.parameter "X" : !hl.int {
-// CHECK:         %18 = macroni.expansion "MUL(A, B)" : !hl.int {
-// CHECK:           %19 = macroni.parameter "A" : !hl.int {
-// CHECK:             %22 = macroni.expansion "ONE" : !hl.int {
-// CHECK:               %23 = hl.const #core.integer<1> : !hl.int
-// CHECK:               hl.value.yield %23 : !hl.int
-// CHECK:             }
-// CHECK:             hl.value.yield %22 : !hl.int
-// CHECK:           }
-// CHECK:           %20 = macroni.parameter "B" : !hl.int {
-// CHECK:             %22 = macroni.expansion "ONE" : !hl.int {
-// CHECK:               %23 = hl.const #core.integer<1> : !hl.int
-// CHECK:               hl.value.yield %23 : !hl.int
-// CHECK:             }
-// CHECK:             hl.value.yield %22 : !hl.int
-// CHECK:           }
-// CHECK:           %21 = hl.mul %19, %20 : (!hl.int, !hl.int) -> !hl.int
-// CHECK:           hl.value.yield %21 : !hl.int
-// CHECK:         }
-// CHECK:         hl.value.yield %18 : !hl.int
-// CHECK:       }
-// CHECK:       %16 = macroni.parameter "Y" : !hl.int {
-// CHECK:         %18 = macroni.expansion "MUL(A, B)" : !hl.int {
-// CHECK:           %19 = macroni.parameter "A" : !hl.int {
-// CHECK:             %22 = macroni.expansion "ONE" : !hl.int {
-// CHECK:               %23 = hl.const #core.integer<1> : !hl.int
-// CHECK:               hl.value.yield %23 : !hl.int
-// CHECK:             }
-// CHECK:             hl.value.yield %22 : !hl.int
-// CHECK:           }
-// CHECK:           %20 = macroni.parameter "B" : !hl.int {
-// CHECK:             %22 = macroni.expansion "ONE" : !hl.int {
-// CHECK:               %23 = hl.const #core.integer<1> : !hl.int
-// CHECK:               hl.value.yield %23 : !hl.int
-// CHECK:             }
-// CHECK:             hl.value.yield %22 : !hl.int
-// CHECK:           }
-// CHECK:           %21 = hl.mul %19, %20 : (!hl.int, !hl.int) -> !hl.int
-// CHECK:           hl.value.yield %21 : !hl.int
-// CHECK:         }
-// CHECK:         hl.value.yield %18 : !hl.int
-// CHECK:       }
-// CHECK:       %17 = hl.add %15, %16 : (!hl.int, !hl.int) -> !hl.int
-// CHECK:       hl.value.yield %17 : !hl.int
-// CHECK:     }
-// CHECK:     hl.value.yield %14 : !hl.int
-// CHECK:   }
-// CHECK:   hl.func @main (%arg0: !hl.lvalue<!hl.int>, %arg1: !hl.lvalue<!hl.decayed<!hl.ptr<!hl.ptr<!hl.char< const >>>>>) -> !hl.int {
-// CHECK:     core.scope {
-// CHECK:       %14 = hl.var "x" : !hl.lvalue<!hl.int>
-// CHECK:       macroni.expansion "DO_NO_TRAILING_SEMI(STMT)" :  {
-// CHECK:         hl.do {
-// CHECK:           core.scope {
-// CHECK:             %16 = macroni.parameter "STMT" : !hl.int {
-// CHECK:               %17 = hl.ref %14 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
-// CHECK:               %18 = hl.const #core.integer<0> : !hl.int
-// CHECK:               %19 = hl.assign %18 to %17 : !hl.int, !hl.lvalue<!hl.int> -> !hl.int
-// CHECK:               hl.value.yield %19 : !hl.int
-// CHECK:             }
-// CHECK:           }
-// CHECK:         } while {
-// CHECK:           %16 = hl.const #core.integer<0> : !hl.int
-// CHECK:           hl.cond.yield %16 : !hl.int
-// CHECK:         }
-// CHECK:       }
-// CHECK:       macroni.expansion "DO_NO_TRAILING_SEMI(STMT)" :  {
-// CHECK:         hl.do {
-// CHECK:           core.scope {
-// CHECK:             macroni.parameter "STMT" :  {
-// CHECK:               macroni.expansion "DO_NO_TRAILING_SEMI(STMT)" :  {
-// CHECK:                 hl.do {
-// CHECK:                   core.scope {
-// CHECK:                     %16 = macroni.parameter "STMT" : !hl.int {
-// CHECK:                       %17 = hl.ref %14 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
-// CHECK:                       %18 = hl.const #core.integer<0> : !hl.int
-// CHECK:                       %19 = hl.assign %18 to %17 : !hl.int, !hl.lvalue<!hl.int> -> !hl.int
-// CHECK:                       hl.value.yield %19 : !hl.int
-// CHECK:                     }
-// CHECK:                   }
-// CHECK:                 } while {
-// CHECK:                   %16 = hl.const #core.integer<0> : !hl.int
-// CHECK:                   hl.cond.yield %16 : !hl.int
-// CHECK:                 }
-// CHECK:               }
-// CHECK:             }
-// CHECK:           }
-// CHECK:         } while {
-// CHECK:           %16 = hl.const #core.integer<0> : !hl.int
-// CHECK:           hl.cond.yield %16 : !hl.int
-// CHECK:         }
-// CHECK:       }
-// CHECK:       macroni.expansion "DO_TRAILING_SEMI(STMT)" :  {
-// CHECK:         hl.do {
-// CHECK:           core.scope {
-// CHECK:             %16 = macroni.parameter "STMT" : !hl.int {
-// CHECK:               %17 = hl.ref %14 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
-// CHECK:               %18 = hl.const #core.integer<1> : !hl.int
-// CHECK:               %19 = hl.assign %18 to %17 : !hl.int, !hl.lvalue<!hl.int> -> !hl.int
-// CHECK:               hl.value.yield %19 : !hl.int
-// CHECK:             }
-// CHECK:           }
-// CHECK:         } while {
-// CHECK:           %16 = hl.const #core.integer<0> : !hl.int
-// CHECK:           hl.cond.yield %16 : !hl.int
-// CHECK:         }
-// CHECK:       }
-// CHECK:       macroni.expansion "DO_TRAILING_SEMI(STMT)" :  {
-// CHECK:         hl.do {
-// CHECK:           core.scope {
-// CHECK:             hl.do {
-// CHECK:               core.scope {
-// CHECK:                 %16 = macroni.parameter "STMT" : !hl.int {
-// CHECK:                   %17 = hl.ref %14 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
-// CHECK:                   %18 = hl.const #core.integer<1> : !hl.int
-// CHECK:                   %19 = hl.assign %18 to %17 : !hl.int, !hl.lvalue<!hl.int> -> !hl.int
-// CHECK:                   hl.value.yield %19 : !hl.int
-// CHECK:                 }
-// CHECK:               }
-// CHECK:             } while {
-// CHECK:               %16 = hl.const #core.integer<0> : !hl.int
-// CHECK:               hl.cond.yield %16 : !hl.int
-// CHECK:             }
-// CHECK:             hl.skip
-// CHECK:           }
-// CHECK:         } while {
-// CHECK:           %16 = hl.const #core.integer<0> : !hl.int
-// CHECK:           hl.cond.yield %16 : !hl.int
-// CHECK:         }
-// CHECK:       }
-// CHECK:       %15 = hl.const #core.integer<0> : !hl.int
-// CHECK:       hl.return %15 : !hl.int
-// CHECK:     }
-// CHECK:   }
-// CHECK: }
-
-
 #define ONE 1
 #define ADD(X, Y) X + Y
 #define MUL(A, B) A * B
@@ -494,3 +33,464 @@ int main(int argc, char const *argv[]) {
 
         return 0;
 }
+
+// CHECK:hl.translation_unit {
+// CHECK:  hl.typedef "__int128_t" : !hl.int128
+// CHECK:  hl.typedef "__uint128_t" : !hl.int128< unsigned >
+// CHECK:  hl.struct "__NSConstantString_tag" {type_visibility = #unsup<attr "type_visibility">} : {
+// CHECK:    hl.field "isa" : !hl.ptr<!hl.int< const >>
+// CHECK:    hl.field "flags" : !hl.int
+// CHECK:    hl.field "str" : !hl.ptr<!hl.char< const >>
+// CHECK:    hl.field "length" : !hl.long
+// CHECK:  }
+// CHECK:  hl.typedef "__NSConstantString" : !hl.record<"__NSConstantString_tag">
+// CHECK:  hl.typedef "__builtin_ms_va_list" : !hl.ptr<!hl.char>
+// CHECK:  hl.struct "__va_list_tag" {type_visibility = #unsup<attr "type_visibility">} : {
+// CHECK:    hl.field "gp_offset" : !hl.int< unsigned >
+// CHECK:    hl.field "fp_offset" : !hl.int< unsigned >
+// CHECK:    hl.field "overflow_arg_area" : !hl.ptr<!hl.void>
+// CHECK:    hl.field "reg_save_area" : !hl.ptr<!hl.void>
+// CHECK:  }
+// CHECK:  hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
+// CHECK:  %0 = hl.var "a" : !hl.lvalue<!hl.int> = {
+// CHECK:    %14 = macroni.expansion "ONE" : !hl.int {
+// CHECK:      %15 = hl.const #core.integer<1> : !hl.int
+// CHECK:      hl.value.yield %15 : !hl.int
+// CHECK:    }
+// CHECK:    hl.value.yield %14 : !hl.int
+// CHECK:  }
+// CHECK:  %1 = hl.var "b" : !hl.lvalue<!hl.int> = {
+// CHECK:    %14 = macroni.expansion "ONE" : !hl.int {
+// CHECK:      %17 = hl.const #core.integer<1> : !hl.int
+// CHECK:      hl.value.yield %17 : !hl.int
+// CHECK:    }
+// CHECK:    %15 = macroni.expansion "ONE" : !hl.int {
+// CHECK:      %17 = hl.const #core.integer<1> : !hl.int
+// CHECK:      hl.value.yield %17 : !hl.int
+// CHECK:    }
+// CHECK:    %16 = hl.add %14, %15 : (!hl.int, !hl.int) -> !hl.int
+// CHECK:    hl.value.yield %16 : !hl.int
+// CHECK:  }
+// CHECK:  %2 = hl.var "c" : !hl.lvalue<!hl.int> = {
+// CHECK:    %14 = macroni.expansion "ADD(X, Y)" : !hl.int {
+// CHECK:      %15 = macroni.parameter "X" : !hl.int {
+// CHECK:        %18 = hl.const #core.integer<1> : !hl.int
+// CHECK:        hl.value.yield %18 : !hl.int
+// CHECK:      }
+// CHECK:      %16 = macroni.parameter "Y" : !hl.int {
+// CHECK:        %18 = hl.const #core.integer<1> : !hl.int
+// CHECK:        hl.value.yield %18 : !hl.int
+// CHECK:      }
+// CHECK:      %17 = hl.add %15, %16 : (!hl.int, !hl.int) -> !hl.int
+// CHECK:      hl.value.yield %17 : !hl.int
+// CHECK:    }
+// CHECK:    hl.value.yield %14 : !hl.int
+// CHECK:  }
+// CHECK:  %3 = hl.var "d" : !hl.lvalue<!hl.int> = {
+// CHECK:    %14 = macroni.expansion "ADD(X, Y)" : !hl.int {
+// CHECK:      %15 = macroni.parameter "X" : !hl.int {
+// CHECK:        %18 = hl.const #core.integer<1> : !hl.int
+// CHECK:        hl.value.yield %18 : !hl.int
+// CHECK:      }
+// CHECK:      %16 = macroni.parameter "Y" : !hl.int {
+// CHECK:        %18 = macroni.expansion "ONE" : !hl.int {
+// CHECK:          %19 = hl.const #core.integer<1> : !hl.int
+// CHECK:          hl.value.yield %19 : !hl.int
+// CHECK:        }
+// CHECK:        hl.value.yield %18 : !hl.int
+// CHECK:      }
+// CHECK:      %17 = hl.add %15, %16 : (!hl.int, !hl.int) -> !hl.int
+// CHECK:      hl.value.yield %17 : !hl.int
+// CHECK:    }
+// CHECK:    hl.value.yield %14 : !hl.int
+// CHECK:  }
+// CHECK:  %4 = hl.var "e" : !hl.lvalue<!hl.int> = {
+// CHECK:    %14 = macroni.expansion "ADD(X, Y)" : !hl.int {
+// CHECK:      %15 = macroni.parameter "X" : !hl.int {
+// CHECK:        %18 = macroni.expansion "ONE" : !hl.int {
+// CHECK:          %19 = hl.const #core.integer<1> : !hl.int
+// CHECK:          hl.value.yield %19 : !hl.int
+// CHECK:        }
+// CHECK:        hl.value.yield %18 : !hl.int
+// CHECK:      }
+// CHECK:      %16 = macroni.parameter "Y" : !hl.int {
+// CHECK:        %18 = hl.const #core.integer<1> : !hl.int
+// CHECK:        hl.value.yield %18 : !hl.int
+// CHECK:      }
+// CHECK:      %17 = hl.add %15, %16 : (!hl.int, !hl.int) -> !hl.int
+// CHECK:      hl.value.yield %17 : !hl.int
+// CHECK:    }
+// CHECK:    hl.value.yield %14 : !hl.int
+// CHECK:  }
+// CHECK:  %5 = hl.var "f" : !hl.lvalue<!hl.int> = {
+// CHECK:    %14 = macroni.expansion "ADD(X, Y)" : !hl.int {
+// CHECK:      %15 = macroni.parameter "X" : !hl.int {
+// CHECK:        %18 = macroni.expansion "ONE" : !hl.int {
+// CHECK:          %19 = hl.const #core.integer<1> : !hl.int
+// CHECK:          hl.value.yield %19 : !hl.int
+// CHECK:        }
+// CHECK:        hl.value.yield %18 : !hl.int
+// CHECK:      }
+// CHECK:      %16 = macroni.parameter "Y" : !hl.int {
+// CHECK:        %18 = macroni.expansion "ONE" : !hl.int {
+// CHECK:          %19 = hl.const #core.integer<1> : !hl.int
+// CHECK:          hl.value.yield %19 : !hl.int
+// CHECK:        }
+// CHECK:        hl.value.yield %18 : !hl.int
+// CHECK:      }
+// CHECK:      %17 = hl.add %15, %16 : (!hl.int, !hl.int) -> !hl.int
+// CHECK:      hl.value.yield %17 : !hl.int
+// CHECK:    }
+// CHECK:    hl.value.yield %14 : !hl.int
+// CHECK:  }
+// CHECK:  %6 = hl.var "g" : !hl.lvalue<!hl.int> = {
+// CHECK:    %14 = macroni.expansion "ADD(X, Y)" : !hl.int {
+// CHECK:      %15 = macroni.parameter "X" : !hl.int {
+// CHECK:        %18 = macroni.expansion "MUL(A, B)" : !hl.int {
+// CHECK:          %19 = macroni.parameter "A" : !hl.int {
+// CHECK:            %22 = hl.const #core.integer<1> : !hl.int
+// CHECK:            hl.value.yield %22 : !hl.int
+// CHECK:          }
+// CHECK:          %20 = macroni.parameter "B" : !hl.int {
+// CHECK:            %22 = hl.const #core.integer<2> : !hl.int
+// CHECK:            hl.value.yield %22 : !hl.int
+// CHECK:          }
+// CHECK:          %21 = hl.mul %19, %20 : (!hl.int, !hl.int) -> !hl.int
+// CHECK:          hl.value.yield %21 : !hl.int
+// CHECK:        }
+// CHECK:        hl.value.yield %18 : !hl.int
+// CHECK:      }
+// CHECK:      %16 = macroni.parameter "Y" : !hl.int {
+// CHECK:        %18 = hl.const #core.integer<3> : !hl.int
+// CHECK:        hl.value.yield %18 : !hl.int
+// CHECK:      }
+// CHECK:      %17 = hl.add %15, %16 : (!hl.int, !hl.int) -> !hl.int
+// CHECK:      hl.value.yield %17 : !hl.int
+// CHECK:    }
+// CHECK:    hl.value.yield %14 : !hl.int
+// CHECK:  }
+// CHECK:  %7 = hl.var "h" : !hl.lvalue<!hl.int> = {
+// CHECK:    %14 = macroni.expansion "ADD(X, Y)" : !hl.int {
+// CHECK:      %15 = macroni.parameter "X" : !hl.int {
+// CHECK:        %18 = hl.const #core.integer<1> : !hl.int
+// CHECK:        hl.value.yield %18 : !hl.int
+// CHECK:      }
+// CHECK:      %16 = macroni.parameter "Y" : !hl.int {
+// CHECK:        %18 = macroni.expansion "MUL(A, B)" : !hl.int {
+// CHECK:          %19 = macroni.parameter "A" : !hl.int {
+// CHECK:            %22 = hl.const #core.integer<2> : !hl.int
+// CHECK:            hl.value.yield %22 : !hl.int
+// CHECK:          }
+// CHECK:          %20 = macroni.parameter "B" : !hl.int {
+// CHECK:            %22 = hl.const #core.integer<3> : !hl.int
+// CHECK:            hl.value.yield %22 : !hl.int
+// CHECK:          }
+// CHECK:          %21 = hl.mul %19, %20 : (!hl.int, !hl.int) -> !hl.int
+// CHECK:          hl.value.yield %21 : !hl.int
+// CHECK:        }
+// CHECK:        hl.value.yield %18 : !hl.int
+// CHECK:      }
+// CHECK:      %17 = hl.add %15, %16 : (!hl.int, !hl.int) -> !hl.int
+// CHECK:      hl.value.yield %17 : !hl.int
+// CHECK:    }
+// CHECK:    hl.value.yield %14 : !hl.int
+// CHECK:  }
+// CHECK:  %8 = hl.var "i" : !hl.lvalue<!hl.int> = {
+// CHECK:    %14 = macroni.expansion "ADD(X, Y)" : !hl.int {
+// CHECK:      %15 = macroni.parameter "X" : !hl.int {
+// CHECK:        %18 = macroni.expansion "ONE" : !hl.int {
+// CHECK:          %19 = hl.const #core.integer<1> : !hl.int
+// CHECK:          hl.value.yield %19 : !hl.int
+// CHECK:        }
+// CHECK:        hl.value.yield %18 : !hl.int
+// CHECK:      }
+// CHECK:      %16 = macroni.parameter "Y" : !hl.int {
+// CHECK:        %18 = macroni.expansion "MUL(A, B)" : !hl.int {
+// CHECK:          %19 = macroni.parameter "A" : !hl.int {
+// CHECK:            %22 = hl.const #core.integer<2> : !hl.int
+// CHECK:            hl.value.yield %22 : !hl.int
+// CHECK:          }
+// CHECK:          %20 = macroni.parameter "B" : !hl.int {
+// CHECK:            %22 = hl.const #core.integer<3> : !hl.int
+// CHECK:            hl.value.yield %22 : !hl.int
+// CHECK:          }
+// CHECK:          %21 = hl.mul %19, %20 : (!hl.int, !hl.int) -> !hl.int
+// CHECK:          hl.value.yield %21 : !hl.int
+// CHECK:        }
+// CHECK:        hl.value.yield %18 : !hl.int
+// CHECK:      }
+// CHECK:      %17 = hl.add %15, %16 : (!hl.int, !hl.int) -> !hl.int
+// CHECK:      hl.value.yield %17 : !hl.int
+// CHECK:    }
+// CHECK:    hl.value.yield %14 : !hl.int
+// CHECK:  }
+// CHECK:  %9 = hl.var "j" : !hl.lvalue<!hl.int> = {
+// CHECK:    %14 = macroni.expansion "ADD(X, Y)" : !hl.int {
+// CHECK:      %15 = macroni.parameter "X" : !hl.int {
+// CHECK:        %18 = macroni.expansion "ONE" : !hl.int {
+// CHECK:          %19 = hl.const #core.integer<1> : !hl.int
+// CHECK:          hl.value.yield %19 : !hl.int
+// CHECK:        }
+// CHECK:        hl.value.yield %18 : !hl.int
+// CHECK:      }
+// CHECK:      %16 = macroni.parameter "Y" : !hl.int {
+// CHECK:        %18 = macroni.expansion "MUL(A, B)" : !hl.int {
+// CHECK:          %19 = macroni.parameter "A" : !hl.int {
+// CHECK:            %22 = macroni.expansion "ONE" : !hl.int {
+// CHECK:              %23 = hl.const #core.integer<1> : !hl.int
+// CHECK:              hl.value.yield %23 : !hl.int
+// CHECK:            }
+// CHECK:            hl.value.yield %22 : !hl.int
+// CHECK:          }
+// CHECK:          %20 = macroni.parameter "B" : !hl.int {
+// CHECK:            %22 = macroni.expansion "ONE" : !hl.int {
+// CHECK:              %23 = hl.const #core.integer<1> : !hl.int
+// CHECK:              hl.value.yield %23 : !hl.int
+// CHECK:            }
+// CHECK:            hl.value.yield %22 : !hl.int
+// CHECK:          }
+// CHECK:          %21 = hl.mul %19, %20 : (!hl.int, !hl.int) -> !hl.int
+// CHECK:          hl.value.yield %21 : !hl.int
+// CHECK:        }
+// CHECK:        hl.value.yield %18 : !hl.int
+// CHECK:      }
+// CHECK:      %17 = hl.add %15, %16 : (!hl.int, !hl.int) -> !hl.int
+// CHECK:      hl.value.yield %17 : !hl.int
+// CHECK:    }
+// CHECK:    hl.value.yield %14 : !hl.int
+// CHECK:  }
+// CHECK:  %10 = hl.var "k" : !hl.lvalue<!hl.int> = {
+// CHECK:    %14 = macroni.expansion "ADD(X, Y)" : !hl.int {
+// CHECK:      %15 = macroni.parameter "X" : !hl.int {
+// CHECK:        %18 = macroni.expansion "MUL(A, B)" : !hl.int {
+// CHECK:          %19 = macroni.parameter "A" : !hl.int {
+// CHECK:            %22 = hl.const #core.integer<1> : !hl.int
+// CHECK:            hl.value.yield %22 : !hl.int
+// CHECK:          }
+// CHECK:          %20 = macroni.parameter "B" : !hl.int {
+// CHECK:            %22 = hl.const #core.integer<2> : !hl.int
+// CHECK:            hl.value.yield %22 : !hl.int
+// CHECK:          }
+// CHECK:          %21 = hl.mul %19, %20 : (!hl.int, !hl.int) -> !hl.int
+// CHECK:          hl.value.yield %21 : !hl.int
+// CHECK:        }
+// CHECK:        hl.value.yield %18 : !hl.int
+// CHECK:      }
+// CHECK:      %16 = macroni.parameter "Y" : !hl.int {
+// CHECK:        %18 = hl.const #core.integer<3> : !hl.int
+// CHECK:        hl.value.yield %18 : !hl.int
+// CHECK:      }
+// CHECK:      %17 = hl.add %15, %16 : (!hl.int, !hl.int) -> !hl.int
+// CHECK:      hl.value.yield %17 : !hl.int
+// CHECK:    }
+// CHECK:    hl.value.yield %14 : !hl.int
+// CHECK:  }
+// CHECK:  %11 = hl.var "l" : !hl.lvalue<!hl.int> = {
+// CHECK:    %14 = macroni.expansion "ADD(X, Y)" : !hl.int {
+// CHECK:      %15 = macroni.parameter "X" : !hl.int {
+// CHECK:        %18 = macroni.expansion "MUL(A, B)" : !hl.int {
+// CHECK:          %19 = macroni.parameter "A" : !hl.int {
+// CHECK:            %22 = hl.const #core.integer<1> : !hl.int
+// CHECK:            hl.value.yield %22 : !hl.int
+// CHECK:          }
+// CHECK:          %20 = macroni.parameter "B" : !hl.int {
+// CHECK:            %22 = hl.const #core.integer<2> : !hl.int
+// CHECK:            hl.value.yield %22 : !hl.int
+// CHECK:          }
+// CHECK:          %21 = hl.mul %19, %20 : (!hl.int, !hl.int) -> !hl.int
+// CHECK:          hl.value.yield %21 : !hl.int
+// CHECK:        }
+// CHECK:        hl.value.yield %18 : !hl.int
+// CHECK:      }
+// CHECK:      %16 = macroni.parameter "Y" : !hl.int {
+// CHECK:        %18 = macroni.expansion "ONE" : !hl.int {
+// CHECK:          %19 = hl.const #core.integer<1> : !hl.int
+// CHECK:          hl.value.yield %19 : !hl.int
+// CHECK:        }
+// CHECK:        hl.value.yield %18 : !hl.int
+// CHECK:      }
+// CHECK:      %17 = hl.add %15, %16 : (!hl.int, !hl.int) -> !hl.int
+// CHECK:      hl.value.yield %17 : !hl.int
+// CHECK:    }
+// CHECK:    hl.value.yield %14 : !hl.int
+// CHECK:  }
+// CHECK:  %12 = hl.var "m" : !hl.lvalue<!hl.int> = {
+// CHECK:    %14 = macroni.expansion "ADD(X, Y)" : !hl.int {
+// CHECK:      %15 = macroni.parameter "X" : !hl.int {
+// CHECK:        %18 = macroni.expansion "MUL(A, B)" : !hl.int {
+// CHECK:          %19 = macroni.parameter "A" : !hl.int {
+// CHECK:            %22 = hl.const #core.integer<1> : !hl.int
+// CHECK:            hl.value.yield %22 : !hl.int
+// CHECK:          }
+// CHECK:          %20 = macroni.parameter "B" : !hl.int {
+// CHECK:            %22 = hl.const #core.integer<2> : !hl.int
+// CHECK:            hl.value.yield %22 : !hl.int
+// CHECK:          }
+// CHECK:          %21 = hl.mul %19, %20 : (!hl.int, !hl.int) -> !hl.int
+// CHECK:          hl.value.yield %21 : !hl.int
+// CHECK:        }
+// CHECK:        hl.value.yield %18 : !hl.int
+// CHECK:      }
+// CHECK:      %16 = macroni.parameter "Y" : !hl.int {
+// CHECK:        %18 = macroni.expansion "MUL(A, B)" : !hl.int {
+// CHECK:          %19 = macroni.parameter "A" : !hl.int {
+// CHECK:            %22 = macroni.expansion "ONE" : !hl.int {
+// CHECK:              %23 = hl.const #core.integer<1> : !hl.int
+// CHECK:              hl.value.yield %23 : !hl.int
+// CHECK:            }
+// CHECK:            hl.value.yield %22 : !hl.int
+// CHECK:          }
+// CHECK:          %20 = macroni.parameter "B" : !hl.int {
+// CHECK:            %22 = macroni.expansion "ONE" : !hl.int {
+// CHECK:              %23 = hl.const #core.integer<1> : !hl.int
+// CHECK:              hl.value.yield %23 : !hl.int
+// CHECK:            }
+// CHECK:            hl.value.yield %22 : !hl.int
+// CHECK:          }
+// CHECK:          %21 = hl.mul %19, %20 : (!hl.int, !hl.int) -> !hl.int
+// CHECK:          hl.value.yield %21 : !hl.int
+// CHECK:        }
+// CHECK:        hl.value.yield %18 : !hl.int
+// CHECK:      }
+// CHECK:      %17 = hl.add %15, %16 : (!hl.int, !hl.int) -> !hl.int
+// CHECK:      hl.value.yield %17 : !hl.int
+// CHECK:    }
+// CHECK:    hl.value.yield %14 : !hl.int
+// CHECK:  }
+// CHECK:  %13 = hl.var "n" : !hl.lvalue<!hl.int> = {
+// CHECK:    %14 = macroni.expansion "ADD(X, Y)" : !hl.int {
+// CHECK:      %15 = macroni.parameter "X" : !hl.int {
+// CHECK:        %18 = macroni.expansion "MUL(A, B)" : !hl.int {
+// CHECK:          %19 = macroni.parameter "A" : !hl.int {
+// CHECK:            %22 = macroni.expansion "ONE" : !hl.int {
+// CHECK:              %23 = hl.const #core.integer<1> : !hl.int
+// CHECK:              hl.value.yield %23 : !hl.int
+// CHECK:            }
+// CHECK:            hl.value.yield %22 : !hl.int
+// CHECK:          }
+// CHECK:          %20 = macroni.parameter "B" : !hl.int {
+// CHECK:            %22 = macroni.expansion "ONE" : !hl.int {
+// CHECK:              %23 = hl.const #core.integer<1> : !hl.int
+// CHECK:              hl.value.yield %23 : !hl.int
+// CHECK:            }
+// CHECK:            hl.value.yield %22 : !hl.int
+// CHECK:          }
+// CHECK:          %21 = hl.mul %19, %20 : (!hl.int, !hl.int) -> !hl.int
+// CHECK:          hl.value.yield %21 : !hl.int
+// CHECK:        }
+// CHECK:        hl.value.yield %18 : !hl.int
+// CHECK:      }
+// CHECK:      %16 = macroni.parameter "Y" : !hl.int {
+// CHECK:        %18 = macroni.expansion "MUL(A, B)" : !hl.int {
+// CHECK:          %19 = macroni.parameter "A" : !hl.int {
+// CHECK:            %22 = macroni.expansion "ONE" : !hl.int {
+// CHECK:              %23 = hl.const #core.integer<1> : !hl.int
+// CHECK:              hl.value.yield %23 : !hl.int
+// CHECK:            }
+// CHECK:            hl.value.yield %22 : !hl.int
+// CHECK:          }
+// CHECK:          %20 = macroni.parameter "B" : !hl.int {
+// CHECK:            %22 = macroni.expansion "ONE" : !hl.int {
+// CHECK:              %23 = hl.const #core.integer<1> : !hl.int
+// CHECK:              hl.value.yield %23 : !hl.int
+// CHECK:            }
+// CHECK:            hl.value.yield %22 : !hl.int
+// CHECK:          }
+// CHECK:          %21 = hl.mul %19, %20 : (!hl.int, !hl.int) -> !hl.int
+// CHECK:          hl.value.yield %21 : !hl.int
+// CHECK:        }
+// CHECK:        hl.value.yield %18 : !hl.int
+// CHECK:      }
+// CHECK:      %17 = hl.add %15, %16 : (!hl.int, !hl.int) -> !hl.int
+// CHECK:      hl.value.yield %17 : !hl.int
+// CHECK:    }
+// CHECK:    hl.value.yield %14 : !hl.int
+// CHECK:  }
+// CHECK:  hl.func @main (%arg0: !hl.lvalue<!hl.int>, %arg1: !hl.lvalue<!hl.decayed<!hl.ptr<!hl.ptr<!hl.char< const >>>>>) -> !hl.int {
+// CHECK:    core.scope {
+// CHECK:      %14 = hl.var "x" : !hl.lvalue<!hl.int>
+// CHECK:      macroni.expansion "DO_NO_TRAILING_SEMI(STMT)" :  {
+// CHECK:        hl.do {
+// CHECK:          core.scope {
+// CHECK:            %16 = macroni.parameter "STMT" : !hl.int {
+// CHECK:              %17 = hl.ref %14 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
+// CHECK:              %18 = hl.const #core.integer<0> : !hl.int
+// CHECK:              %19 = hl.assign %18 to %17 : !hl.int, !hl.lvalue<!hl.int> -> !hl.int
+// CHECK:              hl.value.yield %19 : !hl.int
+// CHECK:            }
+// CHECK:          }
+// CHECK:        } while {
+// CHECK:          %16 = hl.const #core.integer<0> : !hl.int
+// CHECK:          hl.cond.yield %16 : !hl.int
+// CHECK:        }
+// CHECK:      }
+// CHECK:      macroni.expansion "DO_NO_TRAILING_SEMI(STMT)" :  {
+// CHECK:        hl.do {
+// CHECK:          core.scope {
+// CHECK:            macroni.parameter "STMT" :  {
+// CHECK:              macroni.expansion "DO_NO_TRAILING_SEMI(STMT)" :  {
+// CHECK:                hl.do {
+// CHECK:                  core.scope {
+// CHECK:                    %16 = macroni.parameter "STMT" : !hl.int {
+// CHECK:                      %17 = hl.ref %14 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
+// CHECK:                      %18 = hl.const #core.integer<0> : !hl.int
+// CHECK:                      %19 = hl.assign %18 to %17 : !hl.int, !hl.lvalue<!hl.int> -> !hl.int
+// CHECK:                      hl.value.yield %19 : !hl.int
+// CHECK:                    }
+// CHECK:                  }
+// CHECK:                } while {
+// CHECK:                  %16 = hl.const #core.integer<0> : !hl.int
+// CHECK:                  hl.cond.yield %16 : !hl.int
+// CHECK:                }
+// CHECK:              }
+// CHECK:            }
+// CHECK:          }
+// CHECK:        } while {
+// CHECK:          %16 = hl.const #core.integer<0> : !hl.int
+// CHECK:          hl.cond.yield %16 : !hl.int
+// CHECK:        }
+// CHECK:      }
+// CHECK:      macroni.expansion "DO_TRAILING_SEMI(STMT)" :  {
+// CHECK:        hl.do {
+// CHECK:          core.scope {
+// CHECK:            %16 = macroni.parameter "STMT" : !hl.int {
+// CHECK:              %17 = hl.ref %14 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
+// CHECK:              %18 = hl.const #core.integer<1> : !hl.int
+// CHECK:              %19 = hl.assign %18 to %17 : !hl.int, !hl.lvalue<!hl.int> -> !hl.int
+// CHECK:              hl.value.yield %19 : !hl.int
+// CHECK:            }
+// CHECK:          }
+// CHECK:        } while {
+// CHECK:          %16 = hl.const #core.integer<0> : !hl.int
+// CHECK:          hl.cond.yield %16 : !hl.int
+// CHECK:        }
+// CHECK:      }
+// CHECK:      macroni.expansion "DO_TRAILING_SEMI(STMT)" :  {
+// CHECK:        hl.do {
+// CHECK:          core.scope {
+// CHECK:            hl.do {
+// CHECK:              core.scope {
+// CHECK:                %16 = macroni.parameter "STMT" : !hl.int {
+// CHECK:                  %17 = hl.ref %14 : (!hl.lvalue<!hl.int>) -> !hl.lvalue<!hl.int>
+// CHECK:                  %18 = hl.const #core.integer<1> : !hl.int
+// CHECK:                  %19 = hl.assign %18 to %17 : !hl.int, !hl.lvalue<!hl.int> -> !hl.int
+// CHECK:                  hl.value.yield %19 : !hl.int
+// CHECK:                }
+// CHECK:              }
+// CHECK:            } while {
+// CHECK:              %16 = hl.const #core.integer<0> : !hl.int
+// CHECK:              hl.cond.yield %16 : !hl.int
+// CHECK:            }
+// CHECK:            hl.skip
+// CHECK:          }
+// CHECK:        } while {
+// CHECK:          %16 = hl.const #core.integer<0> : !hl.int
+// CHECK:          hl.cond.yield %16 : !hl.int
+// CHECK:        }
+// CHECK:      }
+// CHECK:      %15 = hl.const #core.integer<0> : !hl.int
+// CHECK:      hl.return %15 : !hl.int
+// CHECK:    }
+// CHECK:  }
+// CHECK:}
+

--- a/test/SafetyTests/unsafe.c
+++ b/test/SafetyTests/unsafe.c
@@ -1,34 +1,5 @@
 // RUN: safe-c -x c %s | FileCheck %s --match-full-lines
 
-// CHECK: hl.translation_unit {
-// CHECK:   hl.typedef "__int128_t" : !hl.int128
-// CHECK:   hl.typedef "__uint128_t" : !hl.int128< unsigned >
-// CHECK:   hl.struct "__NSConstantString_tag" : {
-// CHECK:     hl.field "isa" : !hl.ptr<!hl.int< const >>
-// CHECK:     hl.field "flags" : !hl.int
-// CHECK:     hl.field "str" : !hl.ptr<!hl.char< const >>
-// CHECK:     hl.field "length" : !hl.long
-// CHECK:   }
-// CHECK:   hl.typedef "__NSConstantString" : !hl.record<"__NSConstantString_tag">
-// CHECK:   hl.typedef "__builtin_ms_va_list" : !hl.ptr<!hl.char>
-// CHECK:   hl.struct "__va_list_tag" : {
-// CHECK:     hl.field "gp_offset" : !hl.int< unsigned >
-// CHECK:     hl.field "fp_offset" : !hl.int< unsigned >
-// CHECK:     hl.field "overflow_arg_area" : !hl.ptr<!hl.void>
-// CHECK:     hl.field "reg_save_area" : !hl.ptr<!hl.void>
-// CHECK:   }
-// CHECK:   hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
-// CHECK:   hl.func @main () -> !hl.int {
-// CHECK:     core.scope {
-// CHECK:       "safety.unsafe"() ({
-// CHECK:         hl.skip
-// CHECK:       }) : () -> ()
-// CHECK:       %0 = hl.const #core.integer<0> : !hl.int
-// CHECK:       hl.return %0 : !hl.int
-// CHECK:     }
-// CHECK:   }
-// CHECK: }
-
 #define unsafe if (0) ; else
 
 int main(void) {
@@ -37,3 +8,33 @@ int main(void) {
         }
         return 0;
 }
+
+// CHECK:hl.translation_unit {
+// CHECK:  hl.typedef "__int128_t" : !hl.int128
+// CHECK:  hl.typedef "__uint128_t" : !hl.int128< unsigned >
+// CHECK:  hl.struct "__NSConstantString_tag" {type_visibility = #unsup<attr "type_visibility">} : {
+// CHECK:    hl.field "isa" : !hl.ptr<!hl.int< const >>
+// CHECK:    hl.field "flags" : !hl.int
+// CHECK:    hl.field "str" : !hl.ptr<!hl.char< const >>
+// CHECK:    hl.field "length" : !hl.long
+// CHECK:  }
+// CHECK:  hl.typedef "__NSConstantString" : !hl.record<"__NSConstantString_tag">
+// CHECK:  hl.typedef "__builtin_ms_va_list" : !hl.ptr<!hl.char>
+// CHECK:  hl.struct "__va_list_tag" {type_visibility = #unsup<attr "type_visibility">} : {
+// CHECK:    hl.field "gp_offset" : !hl.int< unsigned >
+// CHECK:    hl.field "fp_offset" : !hl.int< unsigned >
+// CHECK:    hl.field "overflow_arg_area" : !hl.ptr<!hl.void>
+// CHECK:    hl.field "reg_save_area" : !hl.ptr<!hl.void>
+// CHECK:  }
+// CHECK:  hl.typedef "__builtin_va_list" : !hl.array<1, !hl.record<"__va_list_tag">>
+// CHECK:  hl.func @main () -> !hl.int {
+// CHECK:    core.scope {
+// CHECK:      "safety.unsafe"() ({
+// CHECK:        hl.skip
+// CHECK:      }) : () -> ()
+// CHECK:      %0 = hl.const #core.integer<0> : !hl.int
+// CHECK:      hl.return %0 : !hl.int
+// CHECK:    }
+// CHECK:  }
+// CHECK:}
+


### PR DESCRIPTION
- Add operations for more `rcu_dereference()`-related kernel macros to the `Kernel` dialect.
- Rewrite VAST `LabelStmt` ops that only contain a single call to `rcu_read_unlock()` into just the call, so that the call be paired with a call to `rcu_read_lock()` and lowered down into an `RCUCriticalSection` op.
- Add checks that `rcu_dereference()`-related kernel macros are not invoked outside of RCU critical sections.
- Add tests for new rewriters and warnings.