### PR TITLE
Code cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 build
 CMakeFiles/
 CMakeUserPresets.json
+compile_commands.json
+tablegen_compile_commands.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
+.cache
 .vscode
 CMakeFiles/
 CMakeUserPresets.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-build
 .cache
 .vscode
+build
 CMakeFiles/
 CMakeUserPresets.json

--- a/bin/Macronify/Main.cpp
+++ b/bin/Macronify/Main.cpp
@@ -23,8 +23,8 @@ int main(int argc, char **argv) {
 
   // Register the MLIR dialects we will be lowering to
   mlir::DialectRegistry registry;
-  registry
-      .insert<vast::hl::HighLevelDialect, macroni::macroni::MacroniDialect>();
+  registry.insert<vast::hl::HighLevelDialect, vast::unsup::UnsupportedDialect,
+                  macroni::macroni::MacroniDialect>();
   auto mctx = mlir::MLIRContext(registry);
 
   // Generate the MLIR

--- a/include/macroni/Translation/MacroniCodeGenVisitorMixin.hpp
+++ b/include/macroni/Translation/MacroniCodeGenVisitorMixin.hpp
@@ -4,11 +4,13 @@
 #include <macroni/Dialect/Macroni/MacroniOps.hpp>
 #include <macroni/Translation/MacroniCodeGenContext.hpp>
 #include <macroni/Translation/MacroniMetaGenerator.hpp>
+#include <memory>
 #include <optional>
 #include <pasta/AST/AST.h>
 #include <pasta/AST/Macro.h>
 #include <pasta/Util/File.h>
 #include <set>
+#include <tuple>
 #include <vast/CodeGen/CodeGen.hpp>
 #include <vast/CodeGen/FallBackVisitor.hpp>
 #include <vast/CodeGen/UnreachableVisitor.hpp>
@@ -118,7 +120,9 @@ struct MacroniCodeGenVisitorMixin
 
     // We call `make_stmt_expr_region` here because a macro may not expand to an
     // expression
-    auto [region, return_type] = make_maybe_value_yield_region(stmt);
+    std::unique_ptr<mlir::Region> region;
+    mlir::Type return_type;
+    std::tie(region, return_type) = make_maybe_value_yield_region(stmt);
 
     // Check if the macro is an expansion or a parameter, and return the
     // appropriate operation

--- a/test/KernelTests/rcu_warnings.c
+++ b/test/KernelTests/rcu_warnings.c
@@ -132,24 +132,24 @@ int main(void) {
         return 0;
 }
 
-// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:44:9: warning: Invocation of rcu_dereference() outside of RCU critical section
-// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:45:9: warning: Invocation of rcu_dereference_bh() outside of RCU critical section
-// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:46:9: warning: Invocation of rcu_dereference_sched() outside of RCU critical section
-// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:18:19: warning: Invocation of rcu_dereference() outside of RCU critical section
-// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:58:9: warning: Invocation of rcu_dereference() outside of RCU critical section
-// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:59:9: warning: Invocation of rcu_dereference_bh() outside of RCU critical section
-// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:60:9: warning: Invocation of rcu_dereference_sched() outside of RCU critical section
-// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:18:19: warning: Invocation of rcu_dereference() outside of RCU critical section
-// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:18:19: warning: Invocation of rcu_dereference() outside of RCU critical section
-// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:91:9: warning: Invocation of rcu_dereference_sched() outside of RCU critical section
-// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:90:9: warning: Invocation of rcu_dereference_bh() outside of RCU critical section
-// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:89:9: warning: Invocation of rcu_dereference() outside of RCU critical section
-// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:18:19: warning: Invocation of rcu_dereference() outside of RCU critical section
-// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:77:9: warning: Invocation of rcu_dereference_sched() outside of RCU critical section
-// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:76:9: warning: Invocation of rcu_dereference_bh() outside of RCU critical section
-// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:75:9: warning: Invocation of rcu_dereference() outside of RCU critical section
-// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:106:9: warning: Invocation of rcu_dereference() outside of RCU critical section
-// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:107:9: warning: Invocation of rcu_dereference_bh() outside of RCU critical section
-// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:108:9: warning: Invocation of rcu_dereference_sched() outside of RCU critical section
-// CHECK:/home/bpappas/trail-of-bits/macroni/test/KernelTests/rcu_warnings.c:18:19: warning: Invocation of rcu_dereference() outside of RCU critical section
+// CHECK::44:9: warning: Invocation of rcu_dereference() outside of RCU critical section
+// CHECK::45:9: warning: Invocation of rcu_dereference_bh() outside of RCU critical section
+// CHECK::46:9: warning: Invocation of rcu_dereference_sched() outside of RCU critical section
+// CHECK::18:19: warning: Invocation of rcu_dereference() outside of RCU critical section
+// CHECK::58:9: warning: Invocation of rcu_dereference() outside of RCU critical section
+// CHECK::59:9: warning: Invocation of rcu_dereference_bh() outside of RCU critical section
+// CHECK::60:9: warning: Invocation of rcu_dereference_sched() outside of RCU critical section
+// CHECK::18:19: warning: Invocation of rcu_dereference() outside of RCU critical section
+// CHECK::18:19: warning: Invocation of rcu_dereference() outside of RCU critical section
+// CHECK::91:9: warning: Invocation of rcu_dereference_sched() outside of RCU critical section
+// CHECK::90:9: warning: Invocation of rcu_dereference_bh() outside of RCU critical section
+// CHECK::89:9: warning: Invocation of rcu_dereference() outside of RCU critical section
+// CHECK::18:19: warning: Invocation of rcu_dereference() outside of RCU critical section
+// CHECK::77:9: warning: Invocation of rcu_dereference_sched() outside of RCU critical section
+// CHECK::76:9: warning: Invocation of rcu_dereference_bh() outside of RCU critical section
+// CHECK::75:9: warning: Invocation of rcu_dereference() outside of RCU critical section
+// CHECK::106:9: warning: Invocation of rcu_dereference() outside of RCU critical section
+// CHECK::107:9: warning: Invocation of rcu_dereference_bh() outside of RCU critical section
+// CHECK::108:9: warning: Invocation of rcu_dereference_sched() outside of RCU critical section
+// CHECK::18:19: warning: Invocation of rcu_dereference() outside of RCU critical section
 


### PR DESCRIPTION
- .gitignore additions and reorganization
- Add unsupported dialect to macronify output
- Use std::tie() to unpack tuple results instead of tuple destructuring for better clangd type inference