### PR TITLE
Add gitsubmodules back to Macroni

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "external/pasta"]
+	path = external/pasta
+	url = https://github.com/trailofbits/pasta
+[submodule "external/vast"]
+	path = external/vast
+	url = https://github.com/PappasBrent/vast.git


### PR DESCRIPTION
Adds the PASTA and VAST submodules back to Macroni (they were removed in c5da13ae1134efe50a7d83ff30de5be9af8ba594 due to CMake issues, but were not added back after these issues were fixed by #20).