### PR TITLE
Preserve op source locations

### DIFF
--- a/bin/Kernelize/Kernelize.cpp
+++ b/bin/Kernelize/Kernelize.cpp
@@ -19,6 +19,17 @@ static llvm::cl::extrahelp
 static llvm::cl::extrahelp
     g_more_help("\nAnalyzes Linux kernel RCU macro usage\n");
 
+static llvm::cl::opt<bool> g_print_locations(
+    "locations",
+    llvm::cl::desc("Enable printing original source locations in MLIR output"),
+    llvm::cl::cat(g_tool_category));
+
+static llvm::cl::alias
+    g_print_locations_alias("l", llvm::cl::desc("Alias for --locations"),
+                            llvm::cl::aliasopt(g_print_locations),
+                            llvm::cl::NotHidden,
+                            llvm::cl::cat(g_tool_category));
+
 int main(int argc, const char **argv) {
   auto ExpectedParser =
       clang::tooling::CommonOptionsParser::create(argc, argv, g_tool_category);
@@ -31,7 +42,7 @@ int main(int argc, const char **argv) {
   clang::tooling::ClangTool Tool(OptionsParser.getCompilations(),
                                  OptionsParser.getSourcePathList());
 
-  macroni::kernel::KernelASTConsumerFactory factory;
+  macroni::kernel::KernelASTConsumerFactory factory(g_print_locations);
 
   return Tool.run(clang::tooling::newFrontendActionFactory(&factory).get());
 }

--- a/bin/Kernelize/Kernelize.cpp
+++ b/bin/Kernelize/Kernelize.cpp
@@ -5,6 +5,7 @@
 // LICENSE file found in the root directory of this source tree.
 
 #include "macroni/ASTConsumers/Kernel/KernelASTConsumer.hpp"
+#include "vast/Util/Common.hpp"
 #include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <clang/Tooling/CommonOptionsParser.h>
 #include <clang/Tooling/Tooling.h>
@@ -42,7 +43,14 @@ int main(int argc, const char **argv) {
   clang::tooling::ClangTool Tool(OptionsParser.getCompilations(),
                                  OptionsParser.getSourcePathList());
 
-  macroni::kernel::KernelASTConsumerFactory factory(g_print_locations);
+  auto mod_handler = [=](vast::owning_module_ref &mod) {
+    mlir::OpPrintingFlags flags;
+    // Only print original locations if the flag is enabled.
+    flags.enableDebugInfo(g_print_locations, false);
+    mod->print(llvm::outs(), flags);
+  };
+
+  macroni::kernel::KernelASTConsumerFactory factory(mod_handler);
 
   return Tool.run(clang::tooling::newFrontendActionFactory(&factory).get());
 }

--- a/include/macroni/ASTConsumers/Kernel/KernelASTConsumer.hpp
+++ b/include/macroni/ASTConsumers/Kernel/KernelASTConsumer.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "macroni/Common/Common.hpp"
 #include <clang/AST/ASTConsumer.h>
 #include <clang/AST/ASTContext.h>
 #include <clang/ASTMatchers/ASTMatchFinder.h>
@@ -8,21 +9,21 @@
 namespace macroni::kernel {
 class KernelASTConsumer : public clang::ASTConsumer {
 public:
-  KernelASTConsumer(bool print_locations);
+  KernelASTConsumer(module_handler mod_handler);
 
   void HandleTranslationUnit(clang::ASTContext &Ctx) override;
 
 private:
-  bool m_print_locations;
+  module_handler m_module_handler;
 };
 
 class KernelASTConsumerFactory {
 public:
   std::unique_ptr<KernelASTConsumer> newASTConsumer(void);
 
-  KernelASTConsumerFactory(bool print_locations);
+  KernelASTConsumerFactory(module_handler mod_handler);
 
 private:
-  bool m_print_locations;
+  module_handler m_module_handler;
 };
 } // namespace macroni::kernel

--- a/include/macroni/ASTConsumers/Kernel/KernelASTConsumer.hpp
+++ b/include/macroni/ASTConsumers/Kernel/KernelASTConsumer.hpp
@@ -8,11 +8,21 @@
 namespace macroni::kernel {
 class KernelASTConsumer : public clang::ASTConsumer {
 public:
+  KernelASTConsumer(bool print_locations);
+
   void HandleTranslationUnit(clang::ASTContext &Ctx) override;
+
+private:
+  bool m_print_locations;
 };
 
 class KernelASTConsumerFactory {
 public:
   std::unique_ptr<KernelASTConsumer> newASTConsumer(void);
+
+  KernelASTConsumerFactory(bool print_locations);
+
+private:
+  bool m_print_locations;
 };
 } // namespace macroni::kernel

--- a/include/macroni/Common/Common.hpp
+++ b/include/macroni/Common/Common.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "vast/Util/Common.hpp"
+#include <functional>
+
+namespace macroni {
+using module_handler = std::function<void(vast::owning_module_ref &)>;
+}

--- a/lib/macroni/ASTConsumers/Kernel/KernelASTConsumer.cpp
+++ b/lib/macroni/ASTConsumers/Kernel/KernelASTConsumer.cpp
@@ -32,8 +32,8 @@ void KernelASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
 
   // Set up the driver.
   auto driver =
-      ::macroni::generate_codegen_driver<KernelDialect,
-                                         macroni::macroni_meta_generator>(Ctx);
+      macroni::generate_codegen_driver<KernelDialect,
+                                       macroni::macroni_meta_generator>(Ctx);
 
   driver->push_visitor(std::make_unique<kernel_visitor>(
       matcher.expansions, Ctx, driver->mcontext(),


### PR DESCRIPTION
Adds command line options to the `kernelize` binary to control whether to print the original source locations that lowered ops come from. By printing the original locations, analysis tools like `kernelcheck` can print the original C code locations where warnings occur, instead of the lowered MLIR locations.