### PR TITLE
Update vast

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,6 +161,11 @@ add_library(macroni_settings INTERFACE)
 include(macroni/compiler_warnings)
 set_target_compiler_warnings(macroni_settings)
 
+# Globally set the required C++ standard. We use C++23 for monadic operations
+# for optionals.
+target_compile_features(macroni_settings INTERFACE cxx_std_23)
+set_target_properties(macroni_settings PROPERTIES CXX_EXTENSIONS ON)
+
 target_include_directories(
   macroni_settings
   INTERFACE $<BUILD_INTERFACE:${MACRONI_SOURCE_DIR}/include>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,20 +201,18 @@ add_subdirectory(external)
 # right now we turn it on project-wide to prevent issues but it would be better
 # to enable it only where it is needed.
 add_compile_definitions(GAP_ENABLE_COROUTINES)
-if(NOT MACRONI_USE_VENDORED_GAP)
-  find_package(gap CONFIG REQUIRED)
-endif()
+# TOOD(bpp): Add the option to use a vendored version of gap. This is more
+# important now that VAST does not offer a vendored version of gap. Also this
+# would prevent the user from accidentally compiling gap with GCC and then
+# trying to compile Macroni with Clang, which would cause compilation errors due
+# to incompatible GCC warnings being passed to Clang.
+find_package(gap CONFIG REQUIRED)
 
 if(NOT MACRONI_USE_VENDORED_PASTA)
   find_package(pasta CONFIG REQUIRED)
 endif()
 
 if(NOT MACRONI_USE_VENDORED_VAST)
-  # TODO(bpp): Allow using vendored VAST without using vendored gap
-  if(MACRONI_USE_VENDORED_GAP)
-    message(
-      FATAL_ERROR "Using non-vendored VAST requires using non-vendored gap")
-  endif()
   find_package(VAST CONFIG REQUIRED)
 endif()
 

--- a/bin/Macronify/CMakeLists.txt
+++ b/bin/Macronify/CMakeLists.txt
@@ -4,6 +4,12 @@ add_executable(macronify Macronify.cpp ParseAST.cpp)
 
 llvm_update_compile_flags(macronify)
 
+# Suppress warnings in PASTA headers.
+set_target_properties(
+  pasta pasta_cxx_settings
+  PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
+             $<TARGET_PROPERTY:pasta,INTERFACE_INCLUDE_DIRECTORIES>)
+
 target_link_libraries(
   macronify PRIVATE macroni_settings pasta pasta_cxx_settings macroni_common
                     macroni_translation_api MLIRMacroni)

--- a/cmake/macroni/project_settings.cmake
+++ b/cmake/macroni/project_settings.cmake
@@ -44,11 +44,6 @@ if(ENABLE_IPO)
   endif()
 endif()
 
-# Globally set the required C++ standard. We use C++23 for monadic operations
-# for optionals.
-set(CMAKE_CXX_STANDARD 23)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
 if(UNIX)
   if(APPLE)
     set(PLATFORM_NAME "macos")

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -5,7 +5,6 @@
 # LICENSE file found in the root directory of this source tree.
 #
 
-option(MACRONI_USE_VENDORED_GAP "Enable build with VAST's gap submodule" ON)
 option(MACRONI_USE_VENDORED_PASTA "Enable build with pasta submodule" ON)
 option(MACRONI_USE_VENDORED_VAST "Enable build with VAST submodule" ON)
 
@@ -30,9 +29,7 @@ if(MACRONI_USE_VENDORED_PASTA)
       CACHE
         BOOL
         "Use Pasta's vendored version of Clang. Will take a long time to build")
-  add_compile_options(-w)
   add_subdirectory(pasta)
-  add_compile_options(-w)
 endif()
 
 if(MACRONI_USE_VENDORED_VAST)

--- a/include/macroni/Common/GenerateModule.hpp
+++ b/include/macroni/Common/GenerateModule.hpp
@@ -61,8 +61,8 @@ maybe_mod_and_context mk_mod_and_mctx(vast::acontext_t &actx,
                                        std::forward<args_t>(args)...) |
       as_node_with_list_ref<attr_visitor_proxy>() |
       as_node<type_caching_proxy>() |
-      as_node_with_list_ref<default_visitor>(*mctx, *bld, mg, sg,
-                                             /* strict return = */ false,
+      as_node_with_list_ref<default_visitor>(*mctx, actx, *bld, mg, sg,
+                                             /* strict return = */ true,
                                              missing_return_policy::emit_trap) |
       as_node_with_list_ref<unsup_visitor>(*mctx, *bld) |
       as_node<fallthrough_visitor>();

--- a/lib/macroni/Translation/Kernel/KernelVisitor.cpp
+++ b/lib/macroni/Translation/Kernel/KernelVisitor.cpp
@@ -9,9 +9,7 @@
 #include "vast/CodeGen/CodeGenMetaGenerator.hpp"
 #include "vast/CodeGen/CodeGenVisitorBase.hpp"
 #include "vast/CodeGen/Common.hpp"
-#include "vast/CodeGen/DefaultDeclVisitor.hpp"
 #include "vast/CodeGen/ScopeContext.hpp"
-#include "vast/CodeGen/SymbolGenerator.hpp"
 #include "vast/Util/Common.hpp"
 #include <clang/AST/Attrs.inc>
 #include <clang/AST/Decl.h>
@@ -122,8 +120,7 @@ vast::operation kernel_visitor::visit(const vast::cg::clang_decl *decl,
 
   // Get the op for this function decl.
 
-  vast::cg::default_decl_visitor visitor(m_mctx, m_bld, m_view, scope);
-  auto op = visitor.visit(decl);
+  auto op = next->visit(decl, scope);
 
   // Attach the present attributes to the operation. Because one function may be
   // annotaed with several RCU attributes (though I'm not sure if any actually

--- a/lib/macroni/Translation/Safety/SafetyVisitor.cpp
+++ b/lib/macroni/Translation/Safety/SafetyVisitor.cpp
@@ -51,8 +51,8 @@ vast::operation safety_visitor::visit(const vast::cg::clang_stmt *stmt,
       .bind(mk_region_builder(else_branch))
       .freeze();
 
-  vast::cg::default_stmt_visitor visitor(m_mctx, m_bld, m_view, scope);
-  auto op = visitor.visit(else_branch);
+  auto op = next->visit(else_branch, scope);
+
   return op;
 }
 } // namespace macroni::safety


### PR DESCRIPTION
- Updates VAST dependency
- Require users to provide their own install of gap
- Adjust CXX standard settings to not be overriden by PASTA's
- Ignore specific PASTA warnings that can cause errors while compiling Macroni